### PR TITLE
feat(status): inspect arbitrary branches

### DIFF
--- a/docs/src/content/docs/cli/status.md
+++ b/docs/src/content/docs/cli/status.md
@@ -4,17 +4,17 @@ description: Show the current AYNIG state for the repo.
 ---
 
 ```bash
-aynig status [options]
+aynig status [branch|pattern] [options]
 ```
 
-`aynig status` prints the current branch state as derived from `HEAD` and the
-available command files in the repository.
+`aynig status` prints the current branch state as derived from `HEAD`, or
+inspects specific local branches without checking them out.
 
 It is a read-only command intended for quick inspection and debugging.
 
 ## Behavior
 
-- Prints the current branch name and `HEAD` commit hash.
+- Prints the inspected branch name and `HEAD` commit hash.
 - Reads the latest commit trailers and reports `dwp-state` and `dwp-run-id`.
 - When the current state is `working`, also reports `dwp-origin-state` when present.
 - Computes lease status as `active`, `expired`, `unknown`, or `n/a`.
@@ -24,6 +24,11 @@ It is a read-only command intended for quick inspection and debugging.
   origin state to resolve.
 - Prefers `.dwp/roles/<role>/command/<state>` over `.dwp/command/<state>` when
   a role is provided.
+- With `--branch` or a positional branch name, inspects that branch directly.
+- With `--branch-pattern` or a positional glob such as `"1-*"`, prints one
+  status block per matching branch.
+- When no branch selector is provided, preserves the current `HEAD`-based
+  behavior.
 
 ## Options
 
@@ -36,6 +41,26 @@ Example:
 
 ```bash
 aynig status --role reviewer
+```
+
+### `--branch <name>`
+
+Inspects a specific local branch without checking it out.
+
+Example:
+
+```bash
+aynig status --branch 1-bootstrap
+```
+
+### `--branch-pattern <pattern>`
+
+Inspects all local branches that match the given glob pattern.
+
+Example:
+
+```bash
+aynig status --branch-pattern "1-*"
 ```
 
 ## Output
@@ -61,6 +86,18 @@ Inspect the current branch:
 
 ```bash
 aynig status
+```
+
+Inspect one branch directly:
+
+```bash
+aynig status 1-bootstrap
+```
+
+Inspect multiple branches with a pattern:
+
+```bash
+aynig status "1-*"
 ```
 
 Resolve commands using a role-specific command directory:

--- a/go/cmd/aynig/main.go
+++ b/go/cmd/aynig/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"all-you-need-is-git/go/internal/commands"
 	"all-you-need-is-git/go/internal/config"
@@ -237,9 +238,40 @@ func printUsage() {
 func statusCmd(args []string) {
 	fs := flag.NewFlagSet("status", flag.ExitOnError)
 	role := fs.String("role", "", "Use role-specific commands from .dwp/roles/<name>/command when available")
+	branch := fs.String("branch", "", "Inspect a specific local branch without checking it out")
+	branchPattern := fs.String("branch-pattern", "", "Inspect all local branches matching the given pattern")
+	fs.Usage = func() {
+		out := fs.Output()
+		fmt.Fprintln(out, "Usage of status:")
+		fmt.Fprintln(out, "  aynig status [branch|pattern] [options]")
+		fmt.Fprintln(out, "  --role <name>")
+		fmt.Fprintln(out, "        Use role-specific commands from .dwp/roles/<name>/command when available")
+		fmt.Fprintln(out, "  --branch <name>")
+		fmt.Fprintln(out, "        Inspect a specific local branch without checking it out")
+		fmt.Fprintln(out, "  --branch-pattern <pattern>")
+		fmt.Fprintln(out, "        Inspect all local branches matching the given pattern")
+	}
 	fs.Parse(args)
+	if fs.NArg() > 1 {
+		fmt.Fprintln(os.Stderr, "status accepts at most one branch or pattern argument")
+		fs.Usage()
+		os.Exit(1)
+	}
+	if fs.NArg() == 1 {
+		selector := fs.Arg(0)
+		if *branch != "" || *branchPattern != "" {
+			fmt.Fprintln(os.Stderr, "status positional branch/pattern cannot be combined with --branch or --branch-pattern")
+			fs.Usage()
+			os.Exit(1)
+		}
+		if strings.ContainsAny(selector, "*?[") {
+			*branchPattern = selector
+		} else {
+			*branch = selector
+		}
+	}
 
-	if err := commands.Status(commands.StatusOptions{Role: *role}); err != nil {
+	if err := commands.Status(commands.StatusOptions{Role: *role, Branch: *branch, BranchPattern: *branchPattern}); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/go/internal/commands/status.go
+++ b/go/internal/commands/status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -31,7 +32,21 @@ func leaseStatusForState(state string, leaseSecondsRaw string, committerDate str
 }
 
 type StatusOptions struct {
-	Role string
+	Role          string
+	Branch        string
+	BranchPattern string
+}
+
+type branchStatus struct {
+	Branch      string
+	HeadCommit  string
+	State       string
+	RunID       string
+	LeaseStatus string
+	OriginState string
+	InDWPState  bool
+	Command     string
+	CommandPath string
 }
 
 func Status(options StatusOptions) error {
@@ -41,33 +56,80 @@ func Status(options StatusOptions) error {
 	}
 	repoRoot = strings.TrimSpace(repoRoot)
 
-	branch, err := gitx.Run("", "rev-parse", "--abbrev-ref", "HEAD")
+	roleName := strings.TrimSpace(options.Role)
+	if roleName == "" {
+		roleName = strings.TrimSpace(os.Getenv("AYNIG_ROLE"))
+	}
+
+	branches, err := resolveStatusBranches(options)
 	if err != nil {
 		return err
 	}
-	branch = strings.TrimSpace(branch)
 
-	headCommit, err := gitx.Run("", "rev-parse", "HEAD")
+	for i, branch := range branches {
+		status, err := readBranchStatus(branch, repoRoot, roleName)
+		if err != nil {
+			return err
+		}
+		printBranchStatus(status)
+		if i < len(branches)-1 {
+			fmt.Println()
+		}
+	}
+	return nil
+}
+
+func resolveStatusBranches(options StatusOptions) ([]string, error) {
+	branch := strings.TrimSpace(options.Branch)
+	pattern := strings.TrimSpace(options.BranchPattern)
+	if branch != "" && pattern != "" {
+		return nil, fmt.Errorf("status accepts either --branch or --branch-pattern, not both")
+	}
+	if branch != "" {
+		if _, err := gitx.Run("", "rev-parse", "--verify", "refs/heads/"+branch); err != nil {
+			return nil, fmt.Errorf("branch %q not found", branch)
+		}
+		return []string{branch}, nil
+	}
+	if pattern != "" {
+		out, err := gitx.Run("", "branch", "--list", "--format=%(refname:short)", pattern)
+		if err != nil {
+			return nil, err
+		}
+		branches := splitStatusLines(out)
+		if len(branches) == 0 {
+			return nil, fmt.Errorf("no branches match pattern %q", pattern)
+		}
+		sort.Strings(branches)
+		return branches, nil
+	}
+	branch, err := gitx.Run("", "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
-		return err
+		return nil, err
+	}
+	return []string{strings.TrimSpace(branch)}, nil
+}
+
+func readBranchStatus(branch string, repoRoot string, roleName string) (branchStatus, error) {
+	headCommit, err := gitx.Run("", "rev-parse", branch)
+	if err != nil {
+		return branchStatus{}, err
 	}
 	headCommit = strings.TrimSpace(headCommit)
 
-	committerDate, err := gitx.Run("", "log", "-1", "--format=%cI")
+	committerDate, err := gitx.Run("", "log", "-1", "--format=%cI", branch)
 	if err != nil {
-		return err
+		return branchStatus{}, err
 	}
 	committerDate = strings.TrimSpace(committerDate)
 
-	fullMessage, err := gitx.Run("", "log", "-1", "--format=%B")
+	fullMessage, err := gitx.Run("", "log", "-1", "--format=%B", branch)
 	if err != nil {
-		return err
+		return branchStatus{}, err
 	}
-	firstLine, _ := splitCommitMessage(fullMessage)
-	_ = firstLine
 	trailers, err := parseTrailersFromMessage(fullMessage)
 	if err != nil {
-		return err
+		return branchStatus{}, err
 	}
 
 	state := trailerValue(trailers, "dwp-state")
@@ -75,7 +137,6 @@ func Status(options StatusOptions) error {
 	leaseSecondsRaw := trailerValue(trailers, "dwp-lease-seconds")
 	originState := trailerValue(trailers, "dwp-origin-state")
 	inDWPState := state != ""
-
 	leaseStatus := leaseStatusForState(state, leaseSecondsRaw, committerDate)
 
 	commandStatus := "missing"
@@ -90,40 +151,58 @@ func Status(options StatusOptions) error {
 	} else if state == "working" {
 		shouldResolveCommand = false
 	}
-
-	roleName := strings.TrimSpace(options.Role)
-	if roleName == "" {
-		roleName = strings.TrimSpace(os.Getenv("AYNIG_ROLE"))
-	}
-
 	if shouldResolveCommand && commandState != "" && commandState != "working" {
 		commandStatus, commandPath = resolveCommandPath(repoRoot, roleName, commandState)
 	} else if !shouldResolveCommand {
 		commandStatus = "lease"
 	}
 
-	fmt.Printf("branch: %s\n", branch)
-	fmt.Printf("head: %s\n", headCommit)
-	if !inDWPState {
+	return branchStatus{
+		Branch:      branch,
+		HeadCommit:  headCommit,
+		State:       state,
+		RunID:       runID,
+		LeaseStatus: leaseStatus,
+		OriginState: originState,
+		InDWPState:  inDWPState,
+		Command:     commandStatus,
+		CommandPath: commandPath,
+	}, nil
+}
+
+func printBranchStatus(status branchStatus) {
+	fmt.Printf("branch: %s\n", status.Branch)
+	fmt.Printf("head: %s\n", status.HeadCommit)
+	if !status.InDWPState {
 		fmt.Printf("dwp-state: not in a DWP state\n")
-		fmt.Printf("command: %s\n", commandStatus)
-		return nil
+		fmt.Printf("command: %s\n", status.Command)
+		return
 	}
-	fmt.Printf("dwp-state: %s\n", state)
-	if state == "working" && originState != "" {
-		fmt.Printf("dwp-origin-state: %s\n", originState)
+	fmt.Printf("dwp-state: %s\n", status.State)
+	if status.State == "working" && status.OriginState != "" {
+		fmt.Printf("dwp-origin-state: %s\n", status.OriginState)
 	}
-	if runID != "" {
-		fmt.Printf("dwp-run-id: %s\n", runID)
+	if status.RunID != "" {
+		fmt.Printf("dwp-run-id: %s\n", status.RunID)
 	} else {
 		fmt.Printf("dwp-run-id: n/a\n")
 	}
-	fmt.Printf("lease: %s\n", leaseStatus)
-	fmt.Printf("command: %s\n", commandStatus)
-	if commandPath != "" {
-		fmt.Printf("command-path: %s\n", commandPath)
+	fmt.Printf("lease: %s\n", status.LeaseStatus)
+	fmt.Printf("command: %s\n", status.Command)
+	if status.CommandPath != "" {
+		fmt.Printf("command-path: %s\n", status.CommandPath)
 	}
-	return nil
+}
+
+func splitStatusLines(out string) []string {
+	lines := []string{}
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			lines = append(lines, trimmed)
+		}
+	}
+	return lines
 }
 
 func resolveCommandPath(repoRoot string, roleName string, commandState string) (string, string) {

--- a/go/internal/commands/status.go
+++ b/go/internal/commands/status.go
@@ -111,19 +111,20 @@ func resolveStatusBranches(options StatusOptions) ([]string, error) {
 }
 
 func readBranchStatus(branch string, repoRoot string, roleName string) (branchStatus, error) {
-	headCommit, err := gitx.Run("", "rev-parse", branch)
+	branchRef := localBranchRef(branch)
+	headCommit, err := gitx.Run("", "rev-parse", branchRef)
 	if err != nil {
 		return branchStatus{}, err
 	}
 	headCommit = strings.TrimSpace(headCommit)
 
-	committerDate, err := gitx.Run("", "log", "-1", "--format=%cI", branch)
+	committerDate, err := gitx.Run("", "log", "-1", "--format=%cI", branchRef)
 	if err != nil {
 		return branchStatus{}, err
 	}
 	committerDate = strings.TrimSpace(committerDate)
 
-	fullMessage, err := gitx.Run("", "log", "-1", "--format=%B", branch)
+	fullMessage, err := gitx.Run("", "log", "-1", "--format=%B", branchRef)
 	if err != nil {
 		return branchStatus{}, err
 	}
@@ -203,6 +204,10 @@ func splitStatusLines(out string) []string {
 		}
 	}
 	return lines
+}
+
+func localBranchRef(branch string) string {
+	return "refs/heads/" + branch
 }
 
 func resolveCommandPath(repoRoot string, roleName string, commandState string) (string, string) {

--- a/go/internal/commands/status_test.go
+++ b/go/internal/commands/status_test.go
@@ -1,8 +1,11 @@
 package commands
 
 import (
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -47,5 +50,146 @@ func TestResolveCommandPathFallsBackToBase(t *testing.T) {
 	}
 	if path != basePath {
 		t.Fatalf("unexpected path: %q", path)
+	}
+}
+
+func TestStatusReadsSpecificBranchWithoutCheckout(t *testing.T) {
+	repoDir := newStatusTestRepo(t)
+	writeExecutable(t, filepath.Join(repoDir, ".dwp", "command", "build"))
+	commitEmpty(t, repoDir, "seed", "body")
+	createBranchCommit(t, repoDir, "1-bootstrap", "feat: bootstrap", "body\n\ndwp-state: build\ndwp-run-id: run-123")
+
+	output := captureStatusOutput(t, repoDir, StatusOptions{Branch: "1-bootstrap"})
+
+	if !strings.Contains(output, "branch: 1-bootstrap\n") {
+		t.Fatalf("expected branch in output, got %q", output)
+	}
+	if !strings.Contains(output, "dwp-state: build\n") {
+		t.Fatalf("expected branch dwp-state in output, got %q", output)
+	}
+	if !strings.Contains(output, "dwp-run-id: run-123\n") {
+		t.Fatalf("expected branch run id in output, got %q", output)
+	}
+	if !strings.Contains(output, "command: exists\n") {
+		t.Fatalf("expected command resolution in output, got %q", output)
+	}
+	current := currentBranch(t, repoDir)
+	if current != "main" {
+		t.Fatalf("status should not checkout the target branch, current branch is %q", current)
+	}
+}
+
+func TestStatusReadsBranchPattern(t *testing.T) {
+	repoDir := newStatusTestRepo(t)
+	writeExecutable(t, filepath.Join(repoDir, ".dwp", "command", "build"))
+	writeExecutable(t, filepath.Join(repoDir, ".dwp", "command", "review"))
+	commitEmpty(t, repoDir, "seed", "body")
+	createBranchCommit(t, repoDir, "1-bootstrap", "feat: bootstrap", "body\n\ndwp-state: build")
+	createBranchCommit(t, repoDir, "1-probing", "feat: probing", "body\n\ndwp-state: review")
+	createBranchCommit(t, repoDir, "other", "feat: other", "body\n\ndwp-state: build")
+
+	output := captureStatusOutput(t, repoDir, StatusOptions{BranchPattern: "1-*"})
+
+	if !strings.Contains(output, "branch: 1-bootstrap\n") || !strings.Contains(output, "branch: 1-probing\n") {
+		t.Fatalf("expected matching branches in output, got %q", output)
+	}
+	if strings.Contains(output, "branch: other\n") {
+		t.Fatalf("unexpected non-matching branch in output, got %q", output)
+	}
+	if strings.Count(output, "branch: ") != 2 {
+		t.Fatalf("expected two branch blocks, got %q", output)
+	}
+	if !strings.Contains(output, "\n\nbranch: 1-probing\n") {
+		t.Fatalf("expected blank line between branch blocks, got %q", output)
+	}
+	current := currentBranch(t, repoDir)
+	if current != "main" {
+		t.Fatalf("status should not checkout matching branches, current branch is %q", current)
+	}
+}
+
+func newStatusTestRepo(t *testing.T) string {
+	t.Helper()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", ".")
+	runGit(t, repoDir, "config", "user.email", "test@example.com")
+	runGit(t, repoDir, "config", "user.name", "Test User")
+	runGit(t, repoDir, "checkout", "-b", "main")
+	return repoDir
+}
+
+func createBranchCommit(t *testing.T, repoDir string, branch string, subject string, body string) {
+	t.Helper()
+	runGit(t, repoDir, "checkout", "-b", branch)
+	commitEmpty(t, repoDir, subject, body)
+	runGit(t, repoDir, "checkout", "main")
+}
+
+func commitEmpty(t *testing.T, repoDir string, subject string, body string) {
+	t.Helper()
+	runGit(t, repoDir, "commit", "--allow-empty", "-m", subject, "-m", body)
+}
+
+func writeExecutable(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+}
+
+func captureStatusOutput(t *testing.T, repoDir string, options StatusOptions) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatalf("chdir failed: %v", err)
+	}
+
+	stdout := os.Stdout
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe failed: %v", err)
+	}
+	os.Stdout = pipeW
+	if err := Status(options); err != nil {
+		_ = pipeW.Close()
+		os.Stdout = stdout
+		t.Fatalf("status failed: %v", err)
+	}
+	_ = pipeW.Close()
+	os.Stdout = stdout
+	output, err := io.ReadAll(pipeR)
+	if err != nil {
+		t.Fatalf("read output failed: %v", err)
+	}
+	return string(output)
+}
+
+func currentBranch(t *testing.T, repoDir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "branch", "--show-current")
+	cmd.Dir = repoDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git branch --show-current failed: %v (%s)", err, string(output))
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v (%s)", strings.Join(args, " "), err, string(output))
 	}
 }

--- a/go/internal/commands/status_test.go
+++ b/go/internal/commands/status_test.go
@@ -108,6 +108,30 @@ func TestStatusReadsBranchPattern(t *testing.T) {
 	}
 }
 
+func TestStatusPrefersLocalBranchRefOverMatchingTag(t *testing.T) {
+	repoDir := newStatusTestRepo(t)
+	writeExecutable(t, filepath.Join(repoDir, ".dwp", "command", "build"))
+	writeExecutable(t, filepath.Join(repoDir, ".dwp", "command", "review"))
+	commitEmpty(t, repoDir, "seed", "body")
+	createBranchCommit(t, repoDir, "foo", "feat: branch foo", "body\n\ndwp-state: build")
+	runGit(t, repoDir, "tag", "foo", "main")
+
+	output := captureStatusOutput(t, repoDir, StatusOptions{Branch: "foo"})
+
+	if !strings.Contains(output, "branch: foo\n") {
+		t.Fatalf("expected branch in output, got %q", output)
+	}
+	if !strings.Contains(output, "dwp-state: build\n") {
+		t.Fatalf("expected branch state to win over tag target, got %q", output)
+	}
+	if strings.Contains(output, "dwp-state: review\n") {
+		t.Fatalf("expected status to ignore matching tag ref, got %q", output)
+	}
+	if !strings.Contains(output, "command: exists\n") {
+		t.Fatalf("expected branch command resolution, got %q", output)
+	}
+}
+
 func newStatusTestRepo(t *testing.T) string {
 	t.Helper()
 	repoDir := t.TempDir()


### PR DESCRIPTION
## Summary
- add branch-aware `aynig status` support for exact branch names and branch glob patterns without requiring checkout
- preserve the current HEAD-based behavior when no selector is provided and keep per-branch output readable for multi-branch queries
- add integration coverage for exact branch and pattern inspection, and document the new CLI forms

## Testing
- go test ./...

Closes #6