### PR TITLE
feat: switch workflow folder to .aynig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,4 @@ config.json
 .worktrees/
 
 /temp/
-.dwp/logs/
+.aynig/logs/

--- a/COMMAND-AGENTS.md
+++ b/COMMAND-AGENTS.md
@@ -4,7 +4,7 @@
 - MUST treat Git commits as the workflow control plane; `dwp-state` trailers are authoritative.
 - MUST NOT guess missing behavior; if not specified here or in docs/CONTRACT.md, mark UNKNOWN.
 - MUST read `HEAD` only for state decisions; history scanning is optional.
-- MUST map state to `.dwp/command/<state>` unless state is reserved (`working`).
+- MUST map state to `.aynig/command/<state>` unless state is reserved (`working`).
 - MUST advance state by creating a new commit with a new `dwp-state` (runner does not).
 - MUST keep commands idempotent when possible; safe re-run is a design goal.
 - MUST respect lease semantics: `working` is reserved and used for mutual exclusion.
@@ -15,15 +15,15 @@
 - Your job: take action for the current `dwp-state`, then create a new commit with the next `dwp-state` trailer.
 
 ## WHERE TO LOOK
-- Available states: `.dwp/COMMANDS.md` (if present) and executable scripts in `.dwp/command/`.
-- Contract: `.dwp/CONTRACT.md`.
+- Available states: `.aynig/COMMANDS.md` (if present) and executable scripts in `.aynig/command/`.
+- Contract: `.aynig/CONTRACT.md`.
 
 ## RELEVANT CLI
 - `aynig set-working` renews the lease (`working`) while the command runs.
 - `aynig set-state` writes the final state commit when the command completes.
 
 ## STATE DISPATCH (SUMMARY)
-- `dwp-state: <state>` maps to `.dwp/command/<state>`.
+- `dwp-state: <state>` maps to `.aynig/command/<state>`.
 - `working` is reserved for leases; never use it as a terminal state.
 
 ## INPUTS YOU RECEIVE

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -48,7 +48,7 @@ AYNIG never interprets business semantics.
 `dwp-state: <state>` → executable command.
 
 If a role is specified (`--role <name>` or `AYNIG_ROLE`), AYNIG first looks for
-`.dwp/roles/<role>/command/<state>` and falls back to `.dwp/command/<state>`.
+`.aynig/roles/<role>/command/<state>` and falls back to `.aynig/command/<state>`.
 
 AYNIG does not define what a state means; it only uses it as a selector.
 Semantics belong to upper layers (frameworks, policies, profiles).

--- a/docs/src/content/docs/cli/init.md
+++ b/docs/src/content/docs/cli/init.md
@@ -16,13 +16,13 @@ created.
 ## Behavior
 
 - Requires the current directory to be a git repository.
-- Creates `.dwp/` if it does not already exist.
-- Creates `.dwp/command/` if it does not already exist.
-- Creates `.dwp/COMMANDS.md` only when `.dwp/` is newly created.
-- Creates `.dwp/CONTRACT.md` when it is missing.
-- Creates `.dwp/command/clean` when it is missing.
+- Creates `.aynig/` if it does not already exist.
+- Creates `.aynig/command/` if it does not already exist.
+- Creates `.aynig/COMMANDS.md` only when `.aynig/` is newly created.
+- Creates `.aynig/CONTRACT.md` when it is missing.
+- Creates `.aynig/command/clean` when it is missing.
 - Creates `.worktrees/` when it is missing.
-- Ensures `.worktrees/` and `.dwp/logs/` are present in `.gitignore`.
+- Ensures `.worktrees/` and `.aynig/logs/` are present in `.gitignore`.
 - Skips existing files instead of overwriting them.
 
 ## Options
@@ -33,13 +33,13 @@ This command has no flags.
 
 Depending on what already exists, `aynig init` may create:
 
-- `.dwp/`
-- `.dwp/COMMANDS.md`
-- `.dwp/CONTRACT.md`
-- `.dwp/command/`
-- `.dwp/command/clean`
+- `.aynig/`
+- `.aynig/COMMANDS.md`
+- `.aynig/CONTRACT.md`
+- `.aynig/command/`
+- `.aynig/command/clean`
 - `.worktrees/`
-- `.gitignore` entries for `.worktrees/` and `.dwp/logs/`
+- `.gitignore` entries for `.worktrees/` and `.aynig/logs/`
 
 ## Examples
 

--- a/docs/src/content/docs/cli/install.md
+++ b/docs/src/content/docs/cli/install.md
@@ -10,8 +10,8 @@ aynig install <repo> [ref] [subfolder]
 `aynig install` clones another repository into a temporary directory and copies
 its workflow files into the current repository.
 
-By default it copies the source repository's `.dwp/` directory into your local
-`.dwp/` directory.
+By default it copies the source repository's `.aynig/` directory into your local
+`.aynig/` directory.
 
 ## Behavior
 
@@ -20,11 +20,11 @@ By default it copies the source repository's `.dwp/` directory into your local
   `https://github.com/owner/name.git`.
 - Clones with `--depth 1`.
 - Uses the provided ref as the clone branch when `[ref]` is given.
-- Copies from `.dwp/` by default, or from `[subfolder]` when provided.
-- Refuses to run when `.dwp/` has uncommitted changes in the current repository.
+- Copies from `.aynig/` by default, or from `[subfolder]` when provided.
+- Refuses to run when `.aynig/` has uncommitted changes in the current repository.
 - Skips source `README.md` files while copying.
 - Reports installed files and overwritten files.
-- When `.dwp/COMMANDS.md` changes, attempts an automatic merge with `opencode`
+- When `.aynig/COMMANDS.md` changes, attempts an automatic merge with `opencode`
   or `claude` when either tool is available.
 
 ## Arguments
@@ -56,7 +56,7 @@ aynig install hacknlove/all-you-need-is-git main
 ### `[subfolder]`
 
 Optional. Copies files from a specific subfolder in the source repository
-instead of the default `.dwp/` directory.
+instead of the default `.aynig/` directory.
 
 Example:
 
@@ -70,7 +70,7 @@ This command has no flags.
 
 ## Examples
 
-Install the default `.dwp/` directory from a GitHub repository:
+Install the default `.aynig/` directory from a GitHub repository:
 
 ```bash
 aynig install hacknlove/all-you-need-is-git

--- a/docs/src/content/docs/cli/run.md
+++ b/docs/src/content/docs/cli/run.md
@@ -23,10 +23,10 @@ It is the main entry point for processing AYNIG state transitions.
 - In remote mode, current-branch resolution is based on the upstream branch of
   the current local branch, such as `origin/main`.
 - `--role` and `ROLE` make AYNIG check
-  `.dwp/roles/<role>/command/<state>` before `.dwp/command/<state>`.
+  `.aynig/roles/<role>/command/<state>` before `.aynig/command/<state>`.
 - Log level precedence is `--log-level` > `dwp-log-level` trailer >
   `LOG_LEVEL` > default `error`.
-- Command stdout and stderr are written to `.dwp/logs/<commit-hash>.log`.
+- Command stdout and stderr are written to `.aynig/logs/<commit-hash>.log`.
 - The command also receives that log path in `LOG_PATH`.
 
 ## Options
@@ -55,7 +55,7 @@ aynig run --remote origin
 
 ### `--role <name>`
 
-Prefers role-specific commands from `.dwp/roles/<name>/command` when present.
+Prefers role-specific commands from `.aynig/roles/<name>/command` when present.
 
 Example:
 

--- a/docs/src/content/docs/cli/status.md
+++ b/docs/src/content/docs/cli/status.md
@@ -22,7 +22,7 @@ It is a read-only command intended for quick inspection and debugging.
   when the current state is `working`.
 - Uses `command: lease` when the current commit is `working` but there is no
   origin state to resolve.
-- Prefers `.dwp/roles/<role>/command/<state>` over `.dwp/command/<state>` when
+- Prefers `.aynig/roles/<role>/command/<state>` over `.aynig/command/<state>` when
   a role is provided.
 - With `--branch` or a positional branch name, inspects that branch directly.
 - With `--branch-pattern` or a positional glob such as `"1-*"`, prints one

--- a/docs/src/content/docs/commands/authoring.md
+++ b/docs/src/content/docs/commands/authoring.md
@@ -1,12 +1,12 @@
 ---
 title: Authoring Commands
-description: Create executable commands in .dwp/command/<state>.
+description: Create executable commands in .aynig/command/<state>.
 ---
 
 Commands are executable files located at:
 
 ```text
-.dwp/command/<state>
+.aynig/command/<state>
 ```
 
 When `dwp-state: <state>` appears in the latest commit trailer, AYNIG executes the matching command.
@@ -16,14 +16,14 @@ When `dwp-state: <state>` appears in the latest commit trailer, AYNIG executes t
 Create a command `review`:
 
 ```bash
-cat > .dwp/command/review <<'EOF'
+cat > .aynig/command/review <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
 echo "Review requested: $BODY"
 EOF
 
-chmod +x .dwp/command/review
+chmod +x .aynig/command/review
 ```
 
 ## Tips

--- a/docs/src/content/docs/commands/environment.md
+++ b/docs/src/content/docs/commands/environment.md
@@ -11,7 +11,7 @@ Common variables:
 - `COMMIT_HASH` — the triggering commit hash
 - `LOG_PATH` — absolute path to the command log file for this run
 - `LOG_LEVEL` — resolved log level for the run/branch
-- `ROLE` — selects `.dwp/roles/<role>/command` when set
+- `ROLE` — selects `.aynig/roles/<role>/command` when set
 - `WORKTREE_PATH` — absolute path to the worktree used for this command run
 
 Precedence: `--log-level` > `dwp-log-level` trailer > `LOG_LEVEL` env.

--- a/docs/src/content/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/getting-started/quick-start.md
@@ -21,13 +21,13 @@ aynig init
 
 This creates:
 
-- `.dwp/` with starter files
+- `.aynig/` with starter files
 - `.worktrees/` for ephemeral execution worktrees
-- `.worktrees/` and `.dwp/logs/` entries in `.gitignore`
+- `.worktrees/` and `.aynig/logs/` entries in `.gitignore`
 
 ## 3) Add a command
 
-Create an executable command at `.dwp/command/human-turn` with something like this:
+Create an executable command at `.aynig/command/human-turn` with something like this:
 
 ```bash
 #!/bin/bash

--- a/docs/src/content/docs/guides/faq.md
+++ b/docs/src/content/docs/guides/faq.md
@@ -27,13 +27,13 @@ Confirm:
 Your state `foo` must have an executable file:
 
 ```text
-.dwp/command/foo
+.aynig/command/foo
 ```
 
 Make it executable:
 
 ```bash
-chmod +x .dwp/command/foo
+chmod +x .aynig/command/foo
 ```
 
 ## "permission denied" running a command

--- a/docs/src/content/docs/guides/glossary.md
+++ b/docs/src/content/docs/guides/glossary.md
@@ -5,7 +5,7 @@ description: Shared vocabulary used throughout AYNIG docs.
 
 - **state**: the value of the `dwp-state:` trailer used to select a command.
 - **trailer**: key/value metadata at the end of a commit message (e.g. `dwp-state: build`).
-- **command**: an executable file at `.dwp/command/<state>`.
+- **command**: an executable file at `.aynig/command/<state>`.
 - **step**: one workflow step: select command → execute → check new `HEAD`.
 - **worktree**: an ephemeral Git worktree created by the runner to isolate execution.
 - **lease**: the distributed lock mechanism implemented via `dwp-state: working` commits.

--- a/docs/src/content/docs/guides/hello-world.md
+++ b/docs/src/content/docs/guides/hello-world.md
@@ -6,7 +6,7 @@ description: A minimal, real workflow you can copy-paste.
 This guide builds the smallest end-to-end workflow:
 
 - You create a commit with `dwp-state: build`
-- AYNIG runs `.dwp/command/build`
+- AYNIG runs `.aynig/command/build`
 - The command emits a new commit advancing the state
 
 ## 1) Initialize the repo
@@ -18,7 +18,7 @@ aynig init
 ## 2) Create a command
 
 ```bash
-cat > .dwp/command/build <<'EOF'
+cat > .aynig/command/build <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -28,7 +28,7 @@ git add build.out
 git commit -m "build: done" -m $'Build completed.\n\ndwp-state: done'
 EOF
 
-chmod +x .dwp/command/build
+chmod +x .aynig/command/build
 ```
 
 ## 3) Request a build (commit protocol)

--- a/docs/src/content/docs/guides/ops-workflow-pack.md
+++ b/docs/src/content/docs/guides/ops-workflow-pack.md
@@ -11,7 +11,7 @@ This repository includes an optional workflow pack in `ops-workflow-pack/`.
 aynig install hacknlove/all-you-need-is-git ops-workflow-pack
 ```
 
-This copies a `.dwp/` directory into your current repository.
+This copies a `.aynig/` directory into your current repository.
 
 ## Included states
 

--- a/docs/src/content/docs/guides/security.md
+++ b/docs/src/content/docs/guides/security.md
@@ -3,7 +3,7 @@ title: Security & Trust Model
 description: What AYNIG assumes and what you must control.
 ---
 
-AYNIG executes code from your repository (`.dwp/command/<state>`). Treat it like CI.
+AYNIG executes code from your repository (`.aynig/command/<state>`). Treat it like CI.
 
 ## What AYNIG assumes
 
@@ -19,13 +19,13 @@ If an attacker can push a commit that sets:
 dwp-state: <some-state>
 ```
 
-they can potentially cause a runner to execute `.dwp/command/<some-state>`.
+they can potentially cause a runner to execute `.aynig/command/<some-state>`.
 
 ## Recommendations
 
 - Run workflows on dedicated branches.
 - Restrict who can push to those branches.
-- Keep `.dwp/command/` small and reviewable.
+- Keep `.aynig/command/` small and reviewable.
 - Prefer running in a sandboxed environment (CI runner / container / VM).
 - Avoid storing secrets in the repo; use environment injection.
 

--- a/docs/src/content/docs/repository/init.md
+++ b/docs/src/content/docs/repository/init.md
@@ -11,7 +11,7 @@ aynig init
 
 This creates:
 
-- `.dwp/` with starter files
-- `.dwp/CONTRACT.md`
+- `.aynig/` with starter files
+- `.aynig/CONTRACT.md`
 - `.worktrees/` for ephemeral execution worktrees
-- `.worktrees/` and `.dwp/logs/` entries in `.gitignore`
+- `.worktrees/` and `.aynig/logs/` entries in `.gitignore`

--- a/docs/src/content/docs/repository/install-workflows.md
+++ b/docs/src/content/docs/repository/install-workflows.md
@@ -1,6 +1,6 @@
 ---
 title: Install Workflow Packs
-description: Copy a workflow pack (.dwp/) from another repo.
+description: Copy a workflow pack (.aynig/) from another repo.
 ---
 
 You can install pre-made workflows from other repositories:
@@ -21,4 +21,4 @@ https://github.com/owner/name.git
 aynig install hacknlove/all-you-need-is-git ops-workflow-pack
 ```
 
-This copies the source `.dwp/` directory into your current repository.
+This copies the source `.aynig/` directory into your current repository.

--- a/docs/src/content/docs/repository/layout.md
+++ b/docs/src/content/docs/repository/layout.md
@@ -6,7 +6,7 @@ description: Recommended layout for AYNIG-enabled repos.
 A minimal AYNIG repository typically includes:
 
 ```text
-.dwp/
+.aynig/
   command/
     <state>
   roles/
@@ -17,13 +17,13 @@ A minimal AYNIG repository typically includes:
 .worktrees/     # ephemeral; created/cleaned by AYNIG
 ```
 
-The `dwp-state` trailer selects which command runs. When `ROLE` (or `--role`) is set, AYNIG checks `.dwp/roles/<role>/command/<state>` first.
+The `dwp-state` trailer selects which command runs. When `ROLE` (or `--role`) is set, AYNIG checks `.aynig/roles/<role>/command/<state>` first.
 
 ## .worktrees/
 
 AYNIG runs each command inside a dedicated Git worktree. Worktrees are created under this directory and reused across runs when possible. This directory is ignored via `.gitignore`.
 
-## .dwp/logs/
+## .aynig/logs/
 
 Command stdout/stderr logs are written here as `<commit-hash>.log`. This directory is ignored via `.gitignore`.
 Keep `.worktrees/` ignored. Commands should not create/manage worktrees manually.

--- a/docs/src/content/docs/run/options.md
+++ b/docs/src/content/docs/run/options.md
@@ -40,5 +40,5 @@ Use `--role <name>` (or set `ROLE`) to run commands from a role-specific directo
 
 Resolution order:
 
-1. `.dwp/roles/<role>/command/<state>`
-2. `.dwp/command/<state>`
+1. `.aynig/roles/<role>/command/<state>`
+2. `.aynig/command/<state>`

--- a/docs/src/content/docs/run/run.md
+++ b/docs/src/content/docs/run/run.md
@@ -10,7 +10,7 @@ description: Execute one workflow step for actionable branches.
 If `HEAD` contains a `dwp-state:` trailer, AYNIG will run:
 
 ```text
-.dwp/command/<state>
+.aynig/command/<state>
 ```
 
 ## Commit format
@@ -53,4 +53,4 @@ Commands receive metadata via env vars such as:
 
 Branch logs use the resolved log level after trailers are parsed. Early branch logs are buffered and flushed once the level is known.
 
-Command stdout/stderr is written to `.dwp/logs/<commit-hash>.log`, where `<commit-hash>` is the commit that triggered the command.
+Command stdout/stderr is written to `.aynig/logs/<commit-hash>.log`, where `<commit-hash>` is the commit that triggered the command.

--- a/docs/src/content/docs/workflows/design.md
+++ b/docs/src/content/docs/workflows/design.md
@@ -5,7 +5,7 @@ description: Design guidance for state machines on top of AYNIG.
 
 Design workflows as explicit state machines:
 
-- Each state has a single command: `.dwp/command/<state>`
+- Each state has a single command: `.aynig/command/<state>`
 - A command does work and emits the next state by creating a commit
 - Keep policies (retries, approvals, gates) in workflow code, not in AYNIG
 

--- a/dwp/DWP-GC.md
+++ b/dwp/DWP-GC.md
@@ -91,7 +91,7 @@ Other bindings MAY reuse `dwp-source` (e.g. HTTP endpoints).
 
 DWP/GC specifies only the Git commit binding rules. It does not define:
 
-- repository layout (e.g. `.dwp/`)
+- repository layout (e.g. `.aynig/`)
 - command resolution paths
 - CLI flags or env vars
 - logging or runner behavior beyond dispatch

--- a/dwp/README.md
+++ b/dwp/README.md
@@ -124,7 +124,7 @@ This repository is intentionally split into three layers:
   - Defines: how DWP is carried via commit messages and Git trailers, and how to parse/resolve `dwp-state`.
   - Does not define: command paths, role resolution, CLI flags, or logging.
 - **AYNIG (implementation)**
-  - Defines: `.dwp/` layout, CLI behavior, env vars, logging, worktrees, and UX defaults.
+  - Defines: `.aynig/` layout, CLI behavior, env vars, logging, worktrees, and UX defaults.
   - Does not define: protocol semantics beyond DWP and DWP/GC.
 
 ---
@@ -142,7 +142,7 @@ This repository is intentionally split into three layers:
 
 - DWP keys are canonical: `dwp-*` only.
 - The binding is named **DWP/GC** for Git commit transport.
-- AYNIG **implements DWP/GC** and uses `.dwp/` as the repo root.
+- AYNIG **implements DWP/GC** and uses `.aynig/` as the repo root.
 - No legacy names are supported.
 
 ---

--- a/go/cmd/aynig/main.go
+++ b/go/cmd/aynig/main.go
@@ -59,7 +59,7 @@ func runCmd(args []string) {
 		out := fs.Output()
 		fmt.Fprintln(out, "Usage of run:")
 		fmt.Fprintln(out, "  --role <name>")
-		fmt.Fprintln(out, "        Use role-specific commands from .dwp/roles/<name>/command when available")
+		fmt.Fprintln(out, "        Use role-specific commands from .aynig/roles/<name>/command when available")
 		fmt.Fprintln(out, "  --current-branch <mode>")
 		fmt.Fprintln(out, "        How to handle the current branch: skip (default), include, only (default \"skip\")")
 		fmt.Fprintln(out, "  --log-level <level>")
@@ -74,7 +74,7 @@ func runCmd(args []string) {
 	fs.StringVar(worktree, "w", config.Default().WorkTree, "Specify custom worktree directory (default: .worktrees)")
 	useRemote := fs.String("remote", "", "Use remote branches instead of local (specify remote name, e.g., origin)")
 	currentBranch := fs.String("current-branch", config.Default().CurrentBranch, "How to handle the current branch: skip (default), include, only")
-	role := fs.String("role", "", "Use role-specific commands from .dwp/roles/<name>/command when available")
+	role := fs.String("role", "", "Use role-specific commands from .aynig/roles/<name>/command when available")
 	logLevel := &stringFlag{value: config.Default().LogLevel}
 	fs.Var(logLevel, "log-level", "Log verbosity: debug, info, warn, error")
 	fs.Parse(args)
@@ -237,7 +237,7 @@ func printUsage() {
 
 func statusCmd(args []string) {
 	fs := flag.NewFlagSet("status", flag.ExitOnError)
-	role := fs.String("role", "", "Use role-specific commands from .dwp/roles/<name>/command when available")
+	role := fs.String("role", "", "Use role-specific commands from .aynig/roles/<name>/command when available")
 	branch := fs.String("branch", "", "Inspect a specific local branch without checking it out")
 	branchPattern := fs.String("branch-pattern", "", "Inspect all local branches matching the given pattern")
 	fs.Usage = func() {
@@ -245,7 +245,7 @@ func statusCmd(args []string) {
 		fmt.Fprintln(out, "Usage of status:")
 		fmt.Fprintln(out, "  aynig status [branch|pattern] [options]")
 		fmt.Fprintln(out, "  --role <name>")
-		fmt.Fprintln(out, "        Use role-specific commands from .dwp/roles/<name>/command when available")
+		fmt.Fprintln(out, "        Use role-specific commands from .aynig/roles/<name>/command when available")
 		fmt.Fprintln(out, "  --branch <name>")
 		fmt.Fprintln(out, "        Inspect a specific local branch without checking it out")
 		fmt.Fprintln(out, "  --branch-pattern <pattern>")

--- a/go/internal/commands/init.go
+++ b/go/internal/commands/init.go
@@ -14,7 +14,7 @@ func Init() error {
 		return fmt.Errorf("Error: Not a Git repository. Please run `git init` first.")
 	}
 
-	dwpDir := ".dwp"
+	dwpDir := ".aynig"
 	dwpCreated := false
 	if err := os.Mkdir(dwpDir, 0o755); err != nil {
 		if !os.IsExist(err) {
@@ -78,7 +78,7 @@ func Init() error {
 	}
 
 	gitignorePath := ".gitignore"
-	gitignoreEntries := []string{".worktrees/", ".dwp/logs/"}
+	gitignoreEntries := []string{".worktrees/", ".aynig/logs/"}
 	gitignoreContent, err := os.ReadFile(gitignorePath)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("Error updating .gitignore: %w", err)

--- a/go/internal/commands/init_test.go
+++ b/go/internal/commands/init_test.go
@@ -31,9 +31,9 @@ func TestInitCreatesCommandDirAndClean(t *testing.T) {
 		t.Fatalf("init failed: %v", err)
 	}
 
-	commandDir := filepath.Join(tempDir, ".dwp", "command")
+	commandDir := filepath.Join(tempDir, ".aynig", "command")
 	cleanCommand := filepath.Join(commandDir, "clean")
-	commandsDoc := filepath.Join(tempDir, ".dwp", "COMMANDS.md")
+	commandsDoc := filepath.Join(tempDir, ".aynig", "COMMANDS.md")
 	gitignore := filepath.Join(tempDir, ".gitignore")
 
 	if _, err := os.Stat(commandDir); err != nil {
@@ -53,7 +53,7 @@ func TestInitCreatesCommandDirAndClean(t *testing.T) {
 	if !stringsContainsLine(string(gitignoreContent), ".worktrees/") {
 		t.Fatalf(".worktrees/ entry missing in .gitignore")
 	}
-	if !stringsContainsLine(string(gitignoreContent), ".dwp/logs/") {
-		t.Fatalf(".dwp/logs/ entry missing in .gitignore")
+	if !stringsContainsLine(string(gitignoreContent), ".aynig/logs/") {
+		t.Fatalf(".aynig/logs/ entry missing in .gitignore")
 	}
 }

--- a/go/internal/commands/install.go
+++ b/go/internal/commands/install.go
@@ -31,7 +31,7 @@ func Install(repo string, ref string, subfolder string) error {
 		return err
 	}
 
-	sourcePath := filepath.Join(tmpDir, ".dwp")
+	sourcePath := filepath.Join(tmpDir, ".aynig")
 	if subfolder != "" {
 		sourcePath = filepath.Join(tmpDir, subfolder)
 	}
@@ -47,16 +47,16 @@ func Install(repo string, ref string, subfolder string) error {
 		if subfolder != "" {
 			return fmt.Errorf("Error: Subfolder not found in %s%s: %s", repo, refInfo, subfolder)
 		}
-		return fmt.Errorf("Error: No .dwp directory found in %s%s%s", repo, refInfo, subfolderInfo)
+		return fmt.Errorf("Error: No .aynig directory found in %s%s%s", repo, refInfo, subfolderInfo)
 	}
 
-	destPath := ".dwp"
+	destPath := ".aynig"
 	statusBefore, err := gitx.StatusPorcelain("", destPath)
 	if err != nil {
 		return err
 	}
 	if strings.TrimSpace(statusBefore) != "" {
-		return fmt.Errorf("\nError: .dwp has uncommitted changes. Please commit or stash them first.")
+		return fmt.Errorf("\nError: .aynig has uncommitted changes. Please commit or stash them first.")
 	}
 
 	fmt.Println("Copying workflows...")
@@ -70,8 +70,8 @@ func Install(repo string, ref string, subfolder string) error {
 	}
 	modified, untracked := parseStatus(statusAfter)
 
-	overwritten := filterFiles(modified, ".dwp/COMMANDS.md")
-	newFiles := filterFiles(untracked, ".dwp/COMMANDS.md")
+	overwritten := filterFiles(modified, ".aynig/COMMANDS.md")
+	newFiles := filterFiles(untracked, ".aynig/COMMANDS.md")
 
 	if len(newFiles) > 0 {
 		fmt.Printf("✓ Installed new: %s\n", strings.Join(newFiles, ", "))
@@ -80,9 +80,9 @@ func Install(repo string, ref string, subfolder string) error {
 		fmt.Printf("⚠  Overwritten: %s\n", strings.Join(overwritten, ", "))
 	}
 
-	commandsMdModified := contains(modified, ".dwp/COMMANDS.md")
+	commandsMdModified := contains(modified, ".aynig/COMMANDS.md")
 	if commandsMdModified && len(overwritten) > 0 {
-		diff, err := gitx.DiffFile("", ".dwp/COMMANDS.md")
+		diff, err := gitx.DiffFile("", ".aynig/COMMANDS.md")
 		if err != nil {
 			return err
 		}
@@ -116,7 +116,7 @@ func Install(repo string, ref string, subfolder string) error {
 			preview := diffPreview(diff, 20)
 			fmt.Printf("\nGit diff preview:\n%s\n", preview)
 			if len(strings.Split(diff, "\n")) > 20 {
-				fmt.Println("... (run `git diff .dwp/COMMANDS.md` to see full diff)")
+				fmt.Println("... (run `git diff .aynig/COMMANDS.md` to see full diff)")
 			}
 		}
 	} else if commandsMdModified {

--- a/go/internal/commands/status.go
+++ b/go/internal/commands/status.go
@@ -214,7 +214,7 @@ func resolveCommandPath(repoRoot string, roleName string, commandState string) (
 	commandStatus := "missing"
 	commandPath := ""
 	if roleName != "" {
-		rolePath := filepath.Join(repoRoot, ".dwp", "roles", filepath.FromSlash(roleName), "command", commandState)
+		rolePath := filepath.Join(repoRoot, ".aynig", "roles", filepath.FromSlash(roleName), "command", commandState)
 		if info, statErr := os.Stat(rolePath); statErr == nil {
 			if info.Mode().IsRegular() && info.Mode()&0o111 != 0 {
 				return "exists", rolePath
@@ -222,7 +222,7 @@ func resolveCommandPath(repoRoot string, roleName string, commandState string) (
 			return "missing", rolePath
 		}
 	}
-	commandPath = filepath.Join(repoRoot, ".dwp", "command", commandState)
+	commandPath = filepath.Join(repoRoot, ".aynig", "command", commandState)
 	if info, statErr := os.Stat(commandPath); statErr == nil {
 		if info.Mode().IsRegular() && info.Mode()&0o111 != 0 {
 			commandStatus = "exists"

--- a/go/internal/commands/status_test.go
+++ b/go/internal/commands/status_test.go
@@ -17,7 +17,7 @@ func TestLeaseStatusForStateNonWorkingIsNA(t *testing.T) {
 
 func TestResolveCommandPathPrefersRole(t *testing.T) {
 	repoRoot := t.TempDir()
-	rolePath := filepath.Join(repoRoot, ".dwp", "roles", "ops", "command", "build")
+	rolePath := filepath.Join(repoRoot, ".aynig", "roles", "ops", "command", "build")
 	if err := os.MkdirAll(filepath.Dir(rolePath), 0o755); err != nil {
 		t.Fatalf("mkdir failed: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestResolveCommandPathPrefersRole(t *testing.T) {
 
 func TestResolveCommandPathFallsBackToBase(t *testing.T) {
 	repoRoot := t.TempDir()
-	basePath := filepath.Join(repoRoot, ".dwp", "command", "build")
+	basePath := filepath.Join(repoRoot, ".aynig", "command", "build")
 	if err := os.MkdirAll(filepath.Dir(basePath), 0o755); err != nil {
 		t.Fatalf("mkdir failed: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestResolveCommandPathFallsBackToBase(t *testing.T) {
 
 func TestStatusReadsSpecificBranchWithoutCheckout(t *testing.T) {
 	repoDir := newStatusTestRepo(t)
-	writeExecutable(t, filepath.Join(repoDir, ".dwp", "command", "build"))
+	writeExecutable(t, filepath.Join(repoDir, ".aynig", "command", "build"))
 	commitEmpty(t, repoDir, "seed", "body")
 	createBranchCommit(t, repoDir, "1-bootstrap", "feat: bootstrap", "body\n\ndwp-state: build\ndwp-run-id: run-123")
 
@@ -81,8 +81,8 @@ func TestStatusReadsSpecificBranchWithoutCheckout(t *testing.T) {
 
 func TestStatusReadsBranchPattern(t *testing.T) {
 	repoDir := newStatusTestRepo(t)
-	writeExecutable(t, filepath.Join(repoDir, ".dwp", "command", "build"))
-	writeExecutable(t, filepath.Join(repoDir, ".dwp", "command", "review"))
+	writeExecutable(t, filepath.Join(repoDir, ".aynig", "command", "build"))
+	writeExecutable(t, filepath.Join(repoDir, ".aynig", "command", "review"))
 	commitEmpty(t, repoDir, "seed", "body")
 	createBranchCommit(t, repoDir, "1-bootstrap", "feat: bootstrap", "body\n\ndwp-state: build")
 	createBranchCommit(t, repoDir, "1-probing", "feat: probing", "body\n\ndwp-state: review")
@@ -110,8 +110,8 @@ func TestStatusReadsBranchPattern(t *testing.T) {
 
 func TestStatusPrefersLocalBranchRefOverMatchingTag(t *testing.T) {
 	repoDir := newStatusTestRepo(t)
-	writeExecutable(t, filepath.Join(repoDir, ".dwp", "command", "build"))
-	writeExecutable(t, filepath.Join(repoDir, ".dwp", "command", "review"))
+	writeExecutable(t, filepath.Join(repoDir, ".aynig", "command", "build"))
+	writeExecutable(t, filepath.Join(repoDir, ".aynig", "command", "review"))
 	commitEmpty(t, repoDir, "seed", "body")
 	createBranchCommit(t, repoDir, "foo", "feat: branch foo", "body\n\ndwp-state: build")
 	runGit(t, repoDir, "tag", "foo", "main")

--- a/go/internal/orchestrator/command.go
+++ b/go/internal/orchestrator/command.go
@@ -253,7 +253,7 @@ func (c *Command) findCommandPath(worktreePath string, commandName string) (stri
 		roleName = roleEnv
 	}
 	if roleName != "" {
-		roleDir := filepath.Join(worktreePath, ".dwp", "roles", filepath.FromSlash(roleName), "command")
+		roleDir := filepath.Join(worktreePath, ".aynig", "roles", filepath.FromSlash(roleName), "command")
 		rolePath, err := c.resolveCommandPath(roleDir, commandName)
 		if err != nil {
 			return "", err
@@ -262,7 +262,7 @@ func (c *Command) findCommandPath(worktreePath string, commandName string) (stri
 			return rolePath, nil
 		}
 	}
-	baseDir := filepath.Join(worktreePath, ".dwp", "command")
+	baseDir := filepath.Join(worktreePath, ".aynig", "command")
 	return c.resolveCommandPath(baseDir, commandName)
 }
 
@@ -343,7 +343,7 @@ func resolveStateTrailer(trailers map[string][]string) (string, string) {
 }
 
 func prepareCommandLogFile(worktreePath string, commitHash string) (*os.File, string, error) {
-	logsDir := filepath.Join(worktreePath, ".dwp", "logs")
+	logsDir := filepath.Join(worktreePath, ".aynig", "logs")
 	if err := os.MkdirAll(logsDir, 0o755); err != nil {
 		return nil, "", err
 	}

--- a/go/internal/orchestrator/command_log_test.go
+++ b/go/internal/orchestrator/command_log_test.go
@@ -17,7 +17,7 @@ func TestPrepareCommandLogFile(t *testing.T) {
 		t.Fatalf("unexpected close error: %v", err)
 	}
 
-	expected := filepath.Join(worktreePath, ".dwp", "logs", "deadbeef.log")
+	expected := filepath.Join(worktreePath, ".aynig", "logs", "deadbeef.log")
 	if logPath != expected {
 		t.Fatalf("unexpected log path: got %q want %q", logPath, expected)
 	}

--- a/go/internal/orchestrator/command_test.go
+++ b/go/internal/orchestrator/command_test.go
@@ -82,7 +82,7 @@ func TestCommandEnvIncludesLogPath(t *testing.T) {
 		LogLevel: "debug",
 	})
 
-	logPath := filepath.Join("/tmp", ".dwp", "logs", "deadbeef.log")
+	logPath := filepath.Join("/tmp", ".aynig", "logs", "deadbeef.log")
 	env := cmd.commandEnv("deadbeef", logPath, "/tmp/worktree")
 
 	wantEntries := []string{

--- a/ops-workflow-pack/README.md
+++ b/ops-workflow-pack/README.md
@@ -3,7 +3,7 @@
 This folder contains an optional workflow pack you can install into any repo.
 
 Included commands live under `ops-workflow-pack/command/` and are intentionally minimal.
-When installed, they copy into `.dwp/command/`.
+When installed, they copy into `.aynig/command/`.
 Use them as starting points and adapt to your own operating patterns.
 
 Install from this repository:

--- a/ops-workflow-pack/command/stalled.md
+++ b/ops-workflow-pack/command/stalled.md
@@ -1,11 +1,11 @@
-Read `.dwp/CONTRACT.md`.
+Read `.aynig/CONTRACT.md`.
 
 The current job is in state `stalled`.
 
 Your goal is to decide the next state.
 
 Instructions:
-1) Read `.dwp/COMMANDS.md` to learn:
+1) Read `.aynig/COMMANDS.md` to learn:
    - available states and their instructions
 2) Find the `working` commit for this run:
    - use `dwp-stalled-run` to locate the last `dwp-state: working` commit for the run


### PR DESCRIPTION
## Summary
- rename the repository workflow folder from `.dwp` to `.aynig` across the CLI, runtime path resolution, and init/install flows
- update tests to assert the new `.aynig` paths for commands, logs, and generated repo files
- refresh docs and reference material to present `.aynig` as the AYNIG-owned folder name

## Testing
- go test ./...

Closes #8