### PR TITLE
[codex] supervise state transitions from command output

### DIFF
--- a/COMMAND-AGENTS.md
+++ b/COMMAND-AGENTS.md
@@ -5,14 +5,14 @@
 - MUST NOT guess missing behavior; if not specified here or in docs/CONTRACT.md, mark UNKNOWN.
 - MUST read `HEAD` only for state decisions; history scanning is optional.
 - MUST map state to `.aynig/command/<state>` unless state is reserved (`working`).
-- MUST advance state by creating a new commit with a new `dwp-state` (runner does not).
+- MUST advance state by emitting `SET_STATE {...}` on stdout; the runner materializes the commit.
 - MUST keep commands idempotent when possible; safe re-run is a design goal.
 - MUST respect lease semantics: `working` is reserved and used for mutual exclusion.
 - MUST treat `.worktrees/` as runner-owned and ephemeral; do not manage worktrees manually.
 
 ## WHAT YOU ARE
 - You are a command agent executed by `aynig run`.
-- Your job: take action for the current `dwp-state`, then create a new commit with the next `dwp-state` trailer.
+- Your job: take action for the current `dwp-state`, then emit a `SET_STATE {...}` line describing the next state.
 
 ## WHERE TO LOOK
 - Available states: `.aynig/COMMANDS.md` (if present) and executable scripts in `.aynig/command/`.
@@ -20,15 +20,21 @@
 
 ## RELEVANT CLI
 - `aynig set-working` renews the lease (`working`) while the command runs.
-- `aynig set-state` writes the final state commit when the command completes.
+- `aynig set-state` is a manual escape hatch for humans; normal command completion goes through `SET_STATE {...}`.
 
 ## STATE DISPATCH (SUMMARY)
 - `dwp-state: <state>` maps to `.aynig/command/<state>`.
 - `working` is reserved for leases; never use it as a terminal state.
 
 ## INPUTS YOU RECEIVE
-- Environment variables (if provided by runner): `BODY`, `COMMIT_HASH`, `LOG_PATH`, `LOG_LEVEL`, `ROLE`, `WORKTREE_PATH`.
+- Environment variables (if provided by runner): `BODY`, `COMMIT_HASH`, `LOG_LEVEL`, `ROLE`, `STDOUT_LOG_PATH`, `STDERR_LOG_PATH`, `WORKTREE_PATH`.
 - Commit trailers are also exposed as uppercase env vars, with dashes converted to underscores. Example: `dwp-state` -> `DWP_STATE`.
+
+## OUTPUT PROTOCOL
+- The runner watches stdout for lines that begin with `SET_STATE `.
+- The text after `SET_STATE ` must be a single-line JSON object.
+- The last valid `SET_STATE` line wins.
+- The runner does not parse stderr for state transitions.
 
 ## COMMIT TRAILER RULES
 - Trailer lines use `key: value` in the commit footer.

--- a/COMMAND-AGENTS.md
+++ b/COMMAND-AGENTS.md
@@ -34,6 +34,9 @@
 - The runner watches stdout for lines that begin with `SET_STATE `.
 - The text after `SET_STATE ` must be a single-line JSON object.
 - The last valid `SET_STATE` line wins.
+- The runner only applies `SET_STATE` if your process exits with code `0`.
+- If your process exits non-zero, AYNIG moves the branch to `stalled`.
+- If your process exits `0` without any valid `SET_STATE`, AYNIG refreshes `working` and keeps waiting.
 - The runner does not parse stderr for state transitions.
 
 ## COMMIT TRAILER RULES

--- a/COMMAND-AGENTS.md
+++ b/COMMAND-AGENTS.md
@@ -34,6 +34,7 @@
 - The runner watches stdout for lines that begin with `SET_STATE `.
 - The text after `SET_STATE ` must be a single-line JSON object.
 - The last valid `SET_STATE` line wins.
+- Use `"keep_trailers": true` when you want AYNIG to preserve existing non-reserved `dwp-*` workflow trailers.
 - The runner only applies `SET_STATE` if your process exits with code `0`.
 - If your process exits non-zero, AYNIG moves the branch to `stalled`.
 - If your process exits `0` without any valid `SET_STATE`, AYNIG refreshes `working` and keeps waiting.

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -82,6 +82,9 @@ SET_STATE {"state":"review","subject":"review: ready","body":"..."}
 AYNIG watches stdout, keeps the **last valid** `SET_STATE` line it sees, and
 creates the final commit after the command exits successfully.
 
+The payload may include `"keep_trailers": true` to preserve existing
+non-reserved `dwp-*` trailers from the current `working` commit.
+
 If the command exits non-zero, AYNIG ignores any observed `SET_STATE` line and
 marks the branch as `stalled` with diagnostic context from stdout/stderr.
 

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -37,7 +37,8 @@ AYNIG:
 2. extracts trailers
 3. resolves the command
 4. executes
-5. validates the result by looking only at the new `HEAD`
+5. watches command stdout for `SET_STATE {...}` lines
+6. materializes the result by writing a new `HEAD`
 
 AYNIG never interprets business semantics.
 
@@ -69,10 +70,17 @@ Metadata is delivered as environment variables.
 AYNIG:
 
 * does not modify the repository during execution
-* does not create final commits
-* does not decide the next state
+* does not infer the next state
+* does not interpret business semantics
 
-**Only the command advances the state machine.**
+The command declares the next state by emitting a line on stdout:
+
+```text
+SET_STATE {"state":"review","subject":"review: ready","body":"..."}
+```
+
+AYNIG watches stdout, keeps the **last valid** `SET_STATE` line it sees, and
+creates the final commit after the command exits.
 
 ---
 
@@ -138,13 +146,15 @@ History is never scanned.
 
 A tick is valid when, after execution:
 
+* the command emitted a valid `SET_STATE {...}` line on stdout
 * `HEAD` contains `dwp-state: <state>`
 * `state != working`
 
 That commit is the **tick output**.
 
-AYNIG does not search previous commits nor attempt to reconstruct history.
-It only observes the latest state.
+AYNIG does not search previous commits nor attempt to reconstruct history. It
+only applies the last valid `SET_STATE` observed in the current run and then
+observes the latest state.
 
 Reason: avoid duplication, loops, and temporal ambiguity.
 
@@ -181,6 +191,7 @@ AYNIG does not:
 * define workflows
 * interpret states
 * scan history
+* parse stderr for state transitions
 * decide merges
 * resolve semantic conflicts
 * guarantee task success

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -80,7 +80,14 @@ SET_STATE {"state":"review","subject":"review: ready","body":"..."}
 ```
 
 AYNIG watches stdout, keeps the **last valid** `SET_STATE` line it sees, and
-creates the final commit after the command exits.
+creates the final commit after the command exits successfully.
+
+If the command exits non-zero, AYNIG ignores any observed `SET_STATE` line and
+marks the branch as `stalled` with diagnostic context from stdout/stderr.
+
+If the command exits zero without emitting a valid `SET_STATE`, AYNIG writes a
+fresh `working` commit with the same trailers to keep the lease alive while
+waiting for any spawned follow-up process.
 
 ---
 
@@ -147,6 +154,7 @@ History is never scanned.
 A tick is valid when, after execution:
 
 * the command emitted a valid `SET_STATE {...}` line on stdout
+* the command exited successfully
 * `HEAD` contains `dwp-state: <state>`
 * `state != working`
 

--- a/docs/src/content/docs/cli/run.md
+++ b/docs/src/content/docs/cli/run.md
@@ -26,8 +26,11 @@ It is the main entry point for processing AYNIG state transitions.
   `.aynig/roles/<role>/command/<state>` before `.aynig/command/<state>`.
 - Log level precedence is `--log-level` > `dwp-log-level` trailer >
   `LOG_LEVEL` > default `error`.
-- Command stdout and stderr are written to `.aynig/logs/<commit-hash>.log`.
-- The command also receives that log path in `LOG_PATH`.
+- Command stdout and stderr are written to separate files:
+  `.aynig/logs/<commit-hash>.stdout.log` and `.aynig/logs/<commit-hash>.stderr.log`.
+- The command receives those paths in `STDOUT_LOG_PATH` and `STDERR_LOG_PATH`.
+- AYNIG watches stdout for lines that begin with `SET_STATE ` and applies the
+  last valid one after the command exits.
 
 ## Options
 

--- a/docs/src/content/docs/cli/run.md
+++ b/docs/src/content/docs/cli/run.md
@@ -30,7 +30,11 @@ It is the main entry point for processing AYNIG state transitions.
   `.aynig/logs/<commit-hash>.stdout.log` and `.aynig/logs/<commit-hash>.stderr.log`.
 - The command receives those paths in `STDOUT_LOG_PATH` and `STDERR_LOG_PATH`.
 - AYNIG watches stdout for lines that begin with `SET_STATE ` and applies the
-  last valid one after the command exits.
+  last valid one after the command exits successfully.
+- If the command exits non-zero, AYNIG marks the branch as `stalled` with a
+  diagnostic body that includes the exit code and recent log lines.
+- If the command exits zero without a valid `SET_STATE`, AYNIG writes a fresh
+  `working` commit and keeps the lease alive.
 
 ## Options
 

--- a/docs/src/content/docs/cli/set-state.md
+++ b/docs/src/content/docs/cli/set-state.md
@@ -11,6 +11,10 @@ aynig set-state --state <state> [options]
 Use it when a DWP run has moved into a new state such as `review`, `failed`, or
 `triage` and you want the runner to take action on the next cycle.
 
+This command is primarily a manual escape hatch. Normal workflow commands are
+expected to emit `SET_STATE {...}` on stdout and let `aynig run` materialize
+the final commit.
+
 The command writes `dwp-state: <state>` automatically, validates trailer
 format, and can push the current branch when a remote is configured.
 

--- a/docs/src/content/docs/commands/authoring.md
+++ b/docs/src/content/docs/commands/authoring.md
@@ -32,6 +32,7 @@ chmod +x .aynig/command/review
 - Commands run with the working directory set to the worktree.
 - Keep commands idempotent when possible.
 - Commands should emit a `SET_STATE {...}` line on stdout instead of creating the final commit directly.
-- The runner watches stdout for lines that begin with `SET_STATE ` and applies the last valid one after the command exits.
+- The runner watches stdout for lines that begin with `SET_STATE ` and applies the last valid one only if the command exits successfully.
+- A non-zero exit moves the branch to `stalled`; a zero exit with no valid `SET_STATE` refreshes `working`.
 - stderr is not parsed for state transitions.
 - Honor `LOG_LEVEL` if your command supports verbosity.

--- a/docs/src/content/docs/commands/authoring.md
+++ b/docs/src/content/docs/commands/authoring.md
@@ -20,7 +20,8 @@ cat > .aynig/command/review <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Review requested: $BODY"
+echo "Review requested: $BODY" >&2
+printf '%s\n' 'SET_STATE {"state":"done","subject":"review: done","body":"Review completed."}'
 EOF
 
 chmod +x .aynig/command/review
@@ -30,6 +31,7 @@ chmod +x .aynig/command/review
 
 - Commands run with the working directory set to the worktree.
 - Keep commands idempotent when possible.
-- Commands should emit a new commit advancing the workflow by setting a new `dwp-state`.
-- Use `LOG_PATH` when a command needs to append related diagnostics to the run log.
+- Commands should emit a `SET_STATE {...}` line on stdout instead of creating the final commit directly.
+- The runner watches stdout for lines that begin with `SET_STATE ` and applies the last valid one after the command exits.
+- stderr is not parsed for state transitions.
 - Honor `LOG_LEVEL` if your command supports verbosity.

--- a/docs/src/content/docs/commands/authoring.md
+++ b/docs/src/content/docs/commands/authoring.md
@@ -21,7 +21,7 @@ cat > .aynig/command/review <<'EOF'
 set -euo pipefail
 
 echo "Review requested: $BODY" >&2
-printf '%s\n' 'SET_STATE {"state":"done","subject":"review: done","body":"Review completed."}'
+printf '%s\n' 'SET_STATE {"state":"done","subject":"review: done","body":"Review completed.","keep_trailers":true}'
 EOF
 
 chmod +x .aynig/command/review
@@ -32,6 +32,7 @@ chmod +x .aynig/command/review
 - Commands run with the working directory set to the worktree.
 - Keep commands idempotent when possible.
 - Commands should emit a `SET_STATE {...}` line on stdout instead of creating the final commit directly.
+- Use `"keep_trailers": true` when the next state should preserve existing workflow metadata such as `dwp-attempt`, `dwp-issue`, or similar `dwp-*` trailers.
 - The runner watches stdout for lines that begin with `SET_STATE ` and applies the last valid one only if the command exits successfully.
 - A non-zero exit moves the branch to `stalled`; a zero exit with no valid `SET_STATE` refreshes `working`.
 - stderr is not parsed for state transitions.

--- a/docs/src/content/docs/commands/environment.md
+++ b/docs/src/content/docs/commands/environment.md
@@ -9,9 +9,10 @@ Common variables:
 
 - `BODY` — the commit message body (prompt)
 - `COMMIT_HASH` — the triggering commit hash
-- `LOG_PATH` — absolute path to the command log file for this run
 - `LOG_LEVEL` — resolved log level for the run/branch
 - `ROLE` — selects `.aynig/roles/<role>/command` when set
+- `STDOUT_LOG_PATH` — absolute path to the stdout log file for this run
+- `STDERR_LOG_PATH` — absolute path to the stderr log file for this run
 - `WORKTREE_PATH` — absolute path to the worktree used for this command run
 
 Precedence: `--log-level` > `dwp-log-level` trailer > `LOG_LEVEL` env.
@@ -23,4 +24,4 @@ Trailers are also exposed as environment variables:
 
 > Implementation note: keys are uppercased and normalized for shells. Trailer-derived
 > variables are skipped when they would overwrite an existing or reserved env var such
-> as `PATH`, `HOME`, `BODY`, `LOG_PATH`, or `ROLE`.
+> as `PATH`, `HOME`, `BODY`, `STDOUT_LOG_PATH`, `STDERR_LOG_PATH`, or `ROLE`.

--- a/docs/src/content/docs/commands/protocol.md
+++ b/docs/src/content/docs/commands/protocol.md
@@ -31,4 +31,18 @@ dwp-state: <state>
 <key>: <value>
 ```
 
-Only the workflow command decides the next state by creating a new commit with a new `dwp-state` trailer.
+## Output protocol
+
+The command declares the next state by writing a single-line JSON payload to stdout:
+
+```text
+SET_STATE {"state":"review","subject":"review: ready","body":"Line 1\nLine 2"}
+```
+
+Rules:
+
+- The runner only interprets stdout for this protocol.
+- The prefix must be exactly `SET_STATE ` at the beginning of the line.
+- The payload must be valid JSON on a single line.
+- If multiple valid `SET_STATE` lines are emitted, the last one wins.
+- The runner creates the final commit after the command exits.

--- a/docs/src/content/docs/commands/protocol.md
+++ b/docs/src/content/docs/commands/protocol.md
@@ -39,6 +39,11 @@ The command declares the next state by writing a single-line JSON payload to std
 SET_STATE {"state":"review","subject":"review: ready","body":"Line 1\nLine 2"}
 ```
 
+Optional fields:
+
+- `keep_trailers: true` copies existing non-reserved `dwp-*` trailers from the current `working` commit into the final state commit.
+- `trailers: [...]` appends explicit trailers after any copied ones, so repeated keys can override by position.
+
 Rules:
 
 - The runner only interprets stdout for this protocol.

--- a/docs/src/content/docs/commands/protocol.md
+++ b/docs/src/content/docs/commands/protocol.md
@@ -45,4 +45,6 @@ Rules:
 - The prefix must be exactly `SET_STATE ` at the beginning of the line.
 - The payload must be valid JSON on a single line.
 - If multiple valid `SET_STATE` lines are emitted, the last one wins.
-- The runner creates the final commit after the command exits.
+- The runner creates the final commit only if the command exits with code `0`.
+- If the command exits non-zero, the runner ignores `SET_STATE` and marks the branch as `stalled`.
+- If the command exits `0` without any valid `SET_STATE`, the runner emits a fresh `working` commit and keeps waiting.

--- a/docs/src/content/docs/commands/protocol.md
+++ b/docs/src/content/docs/commands/protocol.md
@@ -43,6 +43,7 @@ Optional fields:
 
 - `keep_trailers: true` copies existing non-reserved `dwp-*` trailers from the current `working` commit into the final state commit.
 - `trailers: [...]` appends explicit trailers after any copied ones, so repeated keys can override by position.
+- `trailers: [...]` must not include runner-managed keys such as `dwp-state`, `dwp-source`, `dwp-origin-state`, `dwp-run-id`, `dwp-runner-id`, `dwp-lease-seconds`, or `dwp-stalled-run`.
 
 Rules:
 

--- a/docs/src/content/docs/contract/index.md
+++ b/docs/src/content/docs/contract/index.md
@@ -71,7 +71,14 @@ SET_STATE {"state":"review","subject":"review: ready","body":"..."}
 ```
 
 AYNIG watches stdout, keeps the last valid `SET_STATE` line it sees, and
-creates the final commit after the command exits.
+creates the final commit after the command exits successfully.
+
+If the command exits non-zero, AYNIG ignores any observed `SET_STATE` line and
+marks the branch as `stalled` with diagnostic context from stdout/stderr.
+
+If the command exits zero without emitting a valid `SET_STATE`, AYNIG writes a
+fresh `working` commit with the same trailers to keep the lease alive while
+waiting for any spawned follow-up process.
 
 ## 4. Working lease (one runner at a time)
 

--- a/docs/src/content/docs/contract/index.md
+++ b/docs/src/content/docs/contract/index.md
@@ -61,10 +61,17 @@ Metadata is delivered as environment variables.
 AYNIG:
 
 - does not modify the repository during execution
-- does not create final commits
-- does not decide the next state
+- does not infer the next state
+- does not interpret business semantics
 
-**Only the command advances the state machine.**
+The command declares the next state by emitting a line on stdout:
+
+```text
+SET_STATE {"state":"review","subject":"review: ready","body":"..."}
+```
+
+AYNIG watches stdout, keeps the last valid `SET_STATE` line it sees, and
+creates the final commit after the command exits.
 
 ## 4. Working lease (one runner at a time)
 

--- a/docs/src/content/docs/contract/index.md
+++ b/docs/src/content/docs/contract/index.md
@@ -73,6 +73,9 @@ SET_STATE {"state":"review","subject":"review: ready","body":"..."}
 AYNIG watches stdout, keeps the last valid `SET_STATE` line it sees, and
 creates the final commit after the command exits successfully.
 
+The payload may include `"keep_trailers": true` to preserve existing
+non-reserved `dwp-*` trailers from the current `working` commit.
+
 If the command exits non-zero, AYNIG ignores any observed `SET_STATE` line and
 marks the branch as `stalled` with diagnostic context from stdout/stderr.
 

--- a/docs/src/content/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/getting-started/quick-start.md
@@ -64,7 +64,7 @@ dwp-state: human-turn
 aynig run
 ```
 
-AYNIG will read `HEAD`, resolve the command for `dwp-state: human-turn`, execute it, and then the command should produce a new commit advancing the state.
+AYNIG will read `HEAD`, resolve the command for `dwp-state: human-turn`, execute it, and then watch stdout for a `SET_STATE {...}` line to materialize the next state commit.
 
 ## What a command can do
 

--- a/docs/src/content/docs/guides/hello-world.md
+++ b/docs/src/content/docs/guides/hello-world.md
@@ -7,7 +7,7 @@ This guide builds the smallest end-to-end workflow:
 
 - You create a commit with `dwp-state: build`
 - AYNIG runs `.aynig/command/build`
-- The command emits a new commit advancing the state
+- The command emits `SET_STATE {...}` and AYNIG writes the next state commit
 
 ## 1) Initialize the repo
 
@@ -25,7 +25,7 @@ set -euo pipefail
 echo "Build requested: ${BODY}" > build.out
 
 git add build.out
-git commit -m "build: done" -m $'Build completed.\n\ndwp-state: done'
+printf '%s\n' 'SET_STATE {"state":"done","subject":"build: done","body":"Build completed."}'
 EOF
 
 chmod +x .aynig/command/build
@@ -56,5 +56,5 @@ aynig run
 
 ## Notes
 
-- AYNIG does not decide the next state — the command does.
+- AYNIG does not infer the next state — the command declares it with `SET_STATE {...}`.
 - Use `COMMANDS.md` in your repo to document which states exist.

--- a/docs/src/content/docs/guides/hello-world.md
+++ b/docs/src/content/docs/guides/hello-world.md
@@ -25,7 +25,7 @@ set -euo pipefail
 echo "Build requested: ${BODY}" > build.out
 
 git add build.out
-printf '%s\n' 'SET_STATE {"state":"done","subject":"build: done","body":"Build completed."}'
+printf '%s\n' 'SET_STATE {"state":"done","subject":"build: done","body":"Build completed.","keep_trailers":true}'
 EOF
 
 chmod +x .aynig/command/build

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -39,7 +39,7 @@ Then humans also need to coordinate with agents through a different interface, l
 
 ### AYNIG's approach
 
-AYNIG takes a different approach: it uses Git commits as the single source of truth for the workflow. Humans and agents interact through Git, using commit trailers to signal whose turn it is and what to do next. AYNIG runners read the latest commit, run the appropriate command, and check the new commit, ensuring that the workflow progresses smoothly and reliably.
+AYNIG takes a different approach: it uses Git commits as the single source of truth for the workflow. Humans and agents interact through Git, using commit trailers to signal whose turn it is and what to do next. AYNIG runners read the latest commit, run the appropriate command, watch for `SET_STATE {...}` on stdout, and then materialize the new commit, ensuring that the workflow progresses smoothly and reliably.
 Humans can still interact with each other through their preferred channels, and manually with agents when needed, but AYNIG provides them with a clear, auditable, and robust protocol to handle the main parts of the workflow.
 
 

--- a/docs/src/content/docs/operate/retries.md
+++ b/docs/src/content/docs/operate/retries.md
@@ -10,7 +10,7 @@ A simple convention:
 - Use trailers like:
   - `dwp-attempt: 1`
   - `dwp-max-attempts: 3`
-- If a command fails, create a new commit with the same `dwp-state` and increment the attempt.
+- If a command wants a retry, emit `SET_STATE {...}` with the same `dwp-state` and increment the attempt trailer.
 - Stop retrying when attempt reaches max.
 
 These are conventions only; AYNIG does not interpret them.

--- a/docs/src/content/docs/operate/runbooks.md
+++ b/docs/src/content/docs/operate/runbooks.md
@@ -9,8 +9,8 @@ If a command fails, AYNIG does not retry automatically. Your workflow should dec
 
 Common patterns:
 
-- Emit a new commit with a failure state (e.g. `dwp-state: failed`)
-- Increment an attempt trailer (`dwp-attempt:`) and re-emit the same state
+- Emit `SET_STATE {...}` with a failure state (e.g. `dwp-state: failed`)
+- Increment an attempt trailer (`dwp-attempt:`) and re-emit the same state via `SET_STATE {...}`
 - Notify a human (out of band) and stop advancing
 
 ## Working lease stalled

--- a/docs/src/content/docs/repository/layout.md
+++ b/docs/src/content/docs/repository/layout.md
@@ -25,5 +25,6 @@ AYNIG runs each command inside a dedicated Git worktree. Worktrees are created u
 
 ## .aynig/logs/
 
-Command stdout/stderr logs are written here as `<commit-hash>.log`. This directory is ignored via `.gitignore`.
+Command stdout/stderr logs are written here as `<commit-hash>.stdout.log` and
+`<commit-hash>.stderr.log`. This directory is ignored via `.gitignore`.
 Keep `.worktrees/` ignored. Commands should not create/manage worktrees manually.

--- a/docs/src/content/docs/run/run.md
+++ b/docs/src/content/docs/run/run.md
@@ -46,6 +46,8 @@ Commands receive metadata via env vars such as:
 
 - `BODY`
 - `COMMIT_HASH`
+- `STDOUT_LOG_PATH`
+- `STDERR_LOG_PATH`
 - `FOO`
 - `BAZ`
 
@@ -53,4 +55,10 @@ Commands receive metadata via env vars such as:
 
 Branch logs use the resolved log level after trailers are parsed. Early branch logs are buffered and flushed once the level is known.
 
-Command stdout/stderr is written to `.aynig/logs/<commit-hash>.log`, where `<commit-hash>` is the commit that triggered the command.
+Command stdout/stderr is written to `.aynig/logs/<commit-hash>.stdout.log` and
+`.aynig/logs/<commit-hash>.stderr.log`, where `<commit-hash>` is the commit
+that triggered the command.
+
+AYNIG watches stdout for lines that begin with `SET_STATE ` and applies the
+last valid one after the command exits. stderr is not parsed for state
+transitions.

--- a/docs/src/content/docs/run/run.md
+++ b/docs/src/content/docs/run/run.md
@@ -60,5 +60,12 @@ Command stdout/stderr is written to `.aynig/logs/<commit-hash>.stdout.log` and
 that triggered the command.
 
 AYNIG watches stdout for lines that begin with `SET_STATE ` and applies the
-last valid one after the command exits. stderr is not parsed for state
+last valid one after the command exits successfully. stderr is not parsed for state
 transitions.
+
+If the command exits non-zero, AYNIG marks the branch as `stalled` and records
+the exit code plus recent stdout/stderr lines in the commit body.
+
+If the command exits zero without a valid `SET_STATE`, AYNIG refreshes the
+`working` commit and keeps waiting in case the command spawned a follow-up
+process.

--- a/docs/src/content/docs/workflows/design.md
+++ b/docs/src/content/docs/workflows/design.md
@@ -6,7 +6,7 @@ description: Design guidance for state machines on top of AYNIG.
 Design workflows as explicit state machines:
 
 - Each state has a single command: `.aynig/command/<state>`
-- A command does work and emits the next state by creating a commit
+- A command does work and emits the next state by writing `SET_STATE {...}` to stdout
 - Keep policies (retries, approvals, gates) in workflow code, not in AYNIG
 
 Prefer small, idempotent commands and stable trailer conventions.

--- a/go/cmd/aynig/main.go
+++ b/go/cmd/aynig/main.go
@@ -8,6 +8,7 @@ import (
 
 	"all-you-need-is-git/go/internal/commands"
 	"all-you-need-is-git/go/internal/config"
+	"all-you-need-is-git/go/internal/orchestrator"
 )
 
 var version = "dev"
@@ -24,6 +25,8 @@ func main() {
 		fmt.Printf("%s %s\n", version, buildTimestampUnix)
 	case "run":
 		runCmd(os.Args[2:])
+	case "__supervise":
+		superviseCmd(os.Args[2:])
 	case "set-working":
 		setWorkingCmd(os.Args[2:])
 	case "set-state":
@@ -89,6 +92,33 @@ func runCmd(args []string) {
 
 	if err := commands.Run(cfg); err != nil {
 		fmt.Fprintln(os.Stderr, "Error trying to set up the Repository:", err)
+		os.Exit(1)
+	}
+}
+
+func superviseCmd(args []string) {
+	fs := flag.NewFlagSet("__supervise", flag.ExitOnError)
+	worktreePath := fs.String("worktree-path", "", "Worktree path for the supervised command")
+	branch := fs.String("branch", "", "Branch being supervised")
+	commandPath := fs.String("command-path", "", "Executable path of the state command")
+	originState := fs.String("origin-state", "", "State that triggered the command")
+	runID := fs.String("run-id", "", "Run identifier of the working lease")
+	remote := fs.String("remote", "", "Remote to push after applying the final state")
+	stdoutLogPath := fs.String("stdout-log-path", "", "Path to the stdout log")
+	stderrLogPath := fs.String("stderr-log-path", "", "Path to the stderr log")
+	fs.Parse(args)
+
+	if err := orchestrator.Supervise(orchestrator.SuperviseOptions{
+		WorktreePath:  *worktreePath,
+		BranchName:    *branch,
+		CommandPath:   *commandPath,
+		OriginState:   *originState,
+		RunID:         *runID,
+		Remote:        *remote,
+		StdoutLogPath: *stdoutLogPath,
+		StderrLogPath: *stderrLogPath,
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/go/internal/commands/assets/CONTRACT.md
+++ b/go/internal/commands/assets/CONTRACT.md
@@ -79,6 +79,9 @@ SET_STATE {"state":"review","subject":"review: ready","body":"..."}
 AYNIG watches stdout, keeps the **last valid** `SET_STATE` line it sees, and
 creates the final commit after the command exits successfully.
 
+The payload may include `"keep_trailers": true` to preserve existing
+non-reserved `dwp-*` trailers from the current `working` commit.
+
 If the command exits non-zero, AYNIG ignores any observed `SET_STATE` line and
 marks the branch as `stalled` with diagnostic context from stdout/stderr.
 

--- a/go/internal/commands/assets/CONTRACT.md
+++ b/go/internal/commands/assets/CONTRACT.md
@@ -77,7 +77,14 @@ SET_STATE {"state":"review","subject":"review: ready","body":"..."}
 ```
 
 AYNIG watches stdout, keeps the **last valid** `SET_STATE` line it sees, and
-creates the final commit after the command exits.
+creates the final commit after the command exits successfully.
+
+If the command exits non-zero, AYNIG ignores any observed `SET_STATE` line and
+marks the branch as `stalled` with diagnostic context from stdout/stderr.
+
+If the command exits zero without emitting a valid `SET_STATE`, AYNIG writes a
+fresh `working` commit with the same trailers to keep the lease alive while
+waiting for any spawned follow-up process.
 
 ---
 
@@ -144,6 +151,7 @@ History is never scanned.
 A tick is valid when, after execution:
 
 * the command emitted a valid `SET_STATE {...}` line on stdout
+* the command exited successfully
 * `HEAD` contains `dwp-state: <state>`
 * `state != working`
 

--- a/go/internal/commands/assets/CONTRACT.md
+++ b/go/internal/commands/assets/CONTRACT.md
@@ -37,7 +37,8 @@ AYNIG:
 2. extracts trailers
 3. resolves the command
 4. executes
-5. validates the result by looking only at the new `HEAD`
+5. watches command stdout for `SET_STATE {...}` lines
+6. materializes the result by writing a new `HEAD`
 
 AYNIG never interprets business semantics.
 
@@ -66,10 +67,17 @@ Metadata is delivered as environment variables.
 AYNIG:
 
 * does not modify the repository during execution
-* does not create final commits
-* does not decide the next state
+* does not infer the next state
+* does not interpret business semantics
 
-**Only the command advances the state machine.**
+The command declares the next state by emitting a line on stdout:
+
+```text
+SET_STATE {"state":"review","subject":"review: ready","body":"..."}
+```
+
+AYNIG watches stdout, keeps the **last valid** `SET_STATE` line it sees, and
+creates the final commit after the command exits.
 
 ---
 
@@ -135,13 +143,15 @@ History is never scanned.
 
 A tick is valid when, after execution:
 
+* the command emitted a valid `SET_STATE {...}` line on stdout
 * `HEAD` contains `dwp-state: <state>`
 * `state != working`
 
 That commit is the **tick output**.
 
-AYNIG does not search previous commits nor attempt to reconstruct history.
-It only observes the latest state.
+AYNIG does not search previous commits nor attempt to reconstruct history. It
+only applies the last valid `SET_STATE` observed in the current run and then
+observes the latest state.
 
 Reason: avoid duplication, loops, and temporal ambiguity.
 
@@ -178,6 +188,7 @@ AYNIG does not:
 * define workflows
 * interpret states
 * scan history
+* parse stderr for state transitions
 * decide merges
 * resolve semantic conflicts
 * guarantee task success

--- a/go/internal/commands/state_set_common.go
+++ b/go/internal/commands/state_set_common.go
@@ -66,7 +66,11 @@ func parseTrailerArg(raw string) (statex.Trailer, error) {
 	if key == "" {
 		return statex.Trailer{}, fmt.Errorf("Invalid trailer format: %q (empty key)", raw)
 	}
-	return statex.Trailer{Key: key, Value: value}, nil
+	trailer := statex.Trailer{Key: key, Value: value}
+	if err := statex.ValidateTrailer(trailer); err != nil {
+		return statex.Trailer{}, err
+	}
+	return trailer, nil
 }
 
 func resolveDwpRemote(cliRemote string, headTrailers map[string][]string) string {

--- a/go/internal/gitx/commit.go
+++ b/go/internal/gitx/commit.go
@@ -12,7 +12,11 @@ type CommitMessage struct {
 }
 
 func ReadCommit(branch string) (CommitMessage, error) {
-	out, err := Run("", "log", branch, "-1", "--pretty=format:%s%x1f%b%x1f%cI")
+	return ReadCommitInDir("", branch)
+}
+
+func ReadCommitInDir(dir string, branch string) (CommitMessage, error) {
+	out, err := Run(dir, "log", branch, "-1", "--pretty=format:%s%x1f%b%x1f%cI")
 	if err != nil {
 		return CommitMessage{}, err
 	}
@@ -31,7 +35,7 @@ func ReadCommit(branch string) (CommitMessage, error) {
 		fullMessage += "\n\n" + body
 	}
 	if fullMessage != "" {
-		parsed, err := ParseCommitTrailers("", fullMessage)
+		parsed, err := ParseCommitTrailers(dir, fullMessage)
 		if err != nil {
 			return CommitMessage{}, err
 		}

--- a/go/internal/orchestrator/command.go
+++ b/go/internal/orchestrator/command.go
@@ -18,6 +18,8 @@ import (
 	"all-you-need-is-git/go/internal/statex"
 )
 
+var currentExecutablePath = os.Executable
+
 type CommandParams struct {
 	Config          config.Config
 	BranchName      string
@@ -105,7 +107,7 @@ func (c *Command) Run() error {
 		return err
 	}
 
-	commandLog, logPath, err := prepareCommandLogFile(worktreePath, currentCommitHash)
+	stdoutLogPath, stderrLogPath, err := prepareCommandLogPaths(worktreePath, currentCommitHash)
 	if err != nil {
 		return err
 	}
@@ -132,22 +134,45 @@ func (c *Command) Run() error {
 		}
 	}
 
-	env := c.commandEnv(currentCommitHash, logPath, worktreePath)
-
-	cmd := exec.Command(commandPath)
-	cmd.Dir = worktreePath
-	cmd.Env = env
-	cmd.Stdout = commandLog
-	cmd.Stderr = commandLog
-	cmd.Stdin = nil
-	setDetached(cmd)
-	if err := cmd.Start(); err != nil {
-		_ = commandLog.Close()
+	env := c.commandEnv(currentCommitHash, stdoutLogPath, stderrLogPath, worktreePath)
+	executablePath, err := currentExecutablePath()
+	if err != nil {
 		return err
 	}
-	_ = commandLog.Close()
+
+	cmdArgs := []string{
+		"__supervise",
+		"--worktree-path", worktreePath,
+		"--branch", c.branchName,
+		"--command-path", commandPath,
+		"--origin-state", c.command,
+		"--run-id", runID,
+		"--stdout-log-path", stdoutLogPath,
+		"--stderr-log-path", stderrLogPath,
+	}
+	if c.config.UseRemote != "" {
+		cmdArgs = append(cmdArgs, "--remote", c.config.UseRemote)
+	}
+
+	cmd := exec.Command(executablePath, cmdArgs...)
+	cmd.Dir = worktreePath
+	cmd.Env = env
+	cmd.Stdin = nil
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	cmd.Stdout = devNull
+	cmd.Stderr = devNull
+	setDetached(cmd)
+	if err := cmd.Start(); err != nil {
+		_ = devNull.Close()
+		return err
+	}
+	_ = devNull.Close()
 	c.logger.Infof("Launched %s in %s", c.command, worktreePath)
-	c.logger.Debugf("Command log: %s", logPath)
+	c.logger.Debugf("Command stdout log: %s", stdoutLogPath)
+	c.logger.Debugf("Command stderr log: %s", stderrLogPath)
 	_ = cmd.Process.Release()
 	return nil
 }
@@ -342,28 +367,27 @@ func resolveStateTrailer(trailers map[string][]string) (string, string) {
 	return state, ""
 }
 
-func prepareCommandLogFile(worktreePath string, commitHash string) (*os.File, string, error) {
+func prepareCommandLogPaths(worktreePath string, commitHash string) (string, string, error) {
 	logsDir := filepath.Join(worktreePath, ".aynig", "logs")
 	if err := os.MkdirAll(logsDir, 0o755); err != nil {
-		return nil, "", err
+		return "", "", err
 	}
-	logPath := filepath.Join(logsDir, commitHash+".log")
-	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
-	if err != nil {
-		return nil, "", err
-	}
-	return file, logPath, nil
+	stdoutLogPath := filepath.Join(logsDir, commitHash+".stdout.log")
+	stderrLogPath := filepath.Join(logsDir, commitHash+".stderr.log")
+	return stdoutLogPath, stderrLogPath, nil
 }
 
-func (c *Command) commandEnv(commitHash, logPath, worktreePath string) []string {
+func (c *Command) commandEnv(commitHash, stdoutLogPath, stderrLogPath, worktreePath string) []string {
 	env := append([]string{}, os.Environ()...)
 	envNames := envNameSet(env)
 	env = append(env, "BODY="+c.body)
 	envNames["BODY"] = struct{}{}
 	env = append(env, "COMMIT_HASH="+commitHash)
 	envNames["COMMIT_HASH"] = struct{}{}
-	env = append(env, "LOG_PATH="+logPath)
-	envNames["LOG_PATH"] = struct{}{}
+	env = append(env, "STDOUT_LOG_PATH="+stdoutLogPath)
+	envNames["STDOUT_LOG_PATH"] = struct{}{}
+	env = append(env, "STDERR_LOG_PATH="+stderrLogPath)
+	envNames["STDERR_LOG_PATH"] = struct{}{}
 	env = append(env, "WORKTREE_PATH="+worktreePath)
 	envNames["WORKTREE_PATH"] = struct{}{}
 	envNames["ROLE"] = struct{}{}

--- a/go/internal/orchestrator/command_log_test.go
+++ b/go/internal/orchestrator/command_log_test.go
@@ -9,19 +9,25 @@ import (
 func TestPrepareCommandLogFile(t *testing.T) {
 	worktreePath := t.TempDir()
 
-	file, logPath, err := prepareCommandLogFile(worktreePath, "deadbeef")
+	stdoutLogPath, stderrLogPath, err := prepareCommandLogPaths(worktreePath, "deadbeef")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if err := file.Close(); err != nil {
-		t.Fatalf("unexpected close error: %v", err)
+
+	expectedStdout := filepath.Join(worktreePath, ".aynig", "logs", "deadbeef.stdout.log")
+	if stdoutLogPath != expectedStdout {
+		t.Fatalf("unexpected stdout log path: got %q want %q", stdoutLogPath, expectedStdout)
 	}
 
-	expected := filepath.Join(worktreePath, ".aynig", "logs", "deadbeef.log")
-	if logPath != expected {
-		t.Fatalf("unexpected log path: got %q want %q", logPath, expected)
+	expectedStderr := filepath.Join(worktreePath, ".aynig", "logs", "deadbeef.stderr.log")
+	if stderrLogPath != expectedStderr {
+		t.Fatalf("unexpected stderr log path: got %q want %q", stderrLogPath, expectedStderr)
 	}
-	if _, err := os.Stat(logPath); err != nil {
-		t.Fatalf("expected log file to exist: %v", err)
+
+	logsDir := filepath.Join(worktreePath, ".aynig", "logs")
+	if info, err := os.Stat(logsDir); err != nil {
+		t.Fatalf("expected logs directory to exist: %v", err)
+	} else if !info.IsDir() {
+		t.Fatalf("expected logs directory, got file")
 	}
 }

--- a/go/internal/orchestrator/command_test.go
+++ b/go/internal/orchestrator/command_test.go
@@ -71,7 +71,7 @@ func TestGetWorkspaceUsesRepoRootForCurrentBranch(t *testing.T) {
 	}
 }
 
-func TestCommandEnvIncludesLogPath(t *testing.T) {
+func TestCommandEnvIncludesLogPaths(t *testing.T) {
 	cmd := NewCommand(CommandParams{
 		Config: config.Config{Role: "reviewer"},
 		Trailers: map[string][]string{
@@ -82,13 +82,15 @@ func TestCommandEnvIncludesLogPath(t *testing.T) {
 		LogLevel: "debug",
 	})
 
-	logPath := filepath.Join("/tmp", ".aynig", "logs", "deadbeef.log")
-	env := cmd.commandEnv("deadbeef", logPath, "/tmp/worktree")
+	stdoutLogPath := filepath.Join("/tmp", ".aynig", "logs", "deadbeef.stdout.log")
+	stderrLogPath := filepath.Join("/tmp", ".aynig", "logs", "deadbeef.stderr.log")
+	env := cmd.commandEnv("deadbeef", stdoutLogPath, stderrLogPath, "/tmp/worktree")
 
 	wantEntries := []string{
 		"BODY=prompt body",
 		"COMMIT_HASH=deadbeef",
-		"LOG_PATH=" + logPath,
+		"STDOUT_LOG_PATH=" + stdoutLogPath,
+		"STDERR_LOG_PATH=" + stderrLogPath,
 		"WORKTREE_PATH=/tmp/worktree",
 		"LOG_LEVEL=debug",
 		"ROLE=reviewer",
@@ -109,17 +111,18 @@ func TestCommandEnvDoesNotOverrideInheritedOrReservedEnvNames(t *testing.T) {
 	cmd := NewCommand(CommandParams{
 		Config: config.Config{Role: "reviewer"},
 		Trailers: map[string][]string{
-			"path":      {"/tmp/evil-bin"},
-			"home":      {"/tmp/evil-home"},
-			"role":      {"other"},
-			"log-path":  {"/tmp/other.log"},
-			"dwp-state": {"review"},
+			"path":            {"/tmp/evil-bin"},
+			"home":            {"/tmp/evil-home"},
+			"role":            {"other"},
+			"stdout-log-path": {"/tmp/other.stdout.log"},
+			"stderr-log-path": {"/tmp/other.stderr.log"},
+			"dwp-state":       {"review"},
 		},
 		Body:     "prompt body",
 		LogLevel: "debug",
 	})
 
-	env := cmd.commandEnv("deadbeef", "/tmp/log", "/tmp/worktree")
+	env := cmd.commandEnv("deadbeef", "/tmp/stdout.log", "/tmp/stderr.log", "/tmp/worktree")
 
 	if !containsEnvEntry(env, "PATH=/tmp/original-path") {
 		t.Fatalf("expected inherited PATH to be preserved: %v", env)
@@ -136,8 +139,11 @@ func TestCommandEnvDoesNotOverrideInheritedOrReservedEnvNames(t *testing.T) {
 	if containsEnvEntry(env, "ROLE=other") {
 		t.Fatalf("unexpected trailer override for ROLE: %v", env)
 	}
-	if containsEnvEntry(env, "LOG_PATH=/tmp/other.log") {
-		t.Fatalf("unexpected trailer override for LOG_PATH: %v", env)
+	if containsEnvEntry(env, "STDOUT_LOG_PATH=/tmp/other.stdout.log") {
+		t.Fatalf("unexpected trailer override for STDOUT_LOG_PATH: %v", env)
+	}
+	if containsEnvEntry(env, "STDERR_LOG_PATH=/tmp/other.stderr.log") {
+		t.Fatalf("unexpected trailer override for STDERR_LOG_PATH: %v", env)
 	}
 }
 
@@ -152,7 +158,7 @@ func TestCommandEnvReservesRoleEvenWhenUnset(t *testing.T) {
 		LogLevel: "debug",
 	})
 
-	env := cmd.commandEnv("deadbeef", "/tmp/log", "/tmp/worktree")
+	env := cmd.commandEnv("deadbeef", "/tmp/stdout.log", "/tmp/stderr.log", "/tmp/worktree")
 
 	if containsEnvEntry(env, "ROLE=reviewer") {
 		t.Fatalf("unexpected trailer-created ROLE when no role was configured: %v", env)

--- a/go/internal/orchestrator/supervisor.go
+++ b/go/internal/orchestrator/supervisor.go
@@ -30,10 +30,11 @@ type SuperviseOptions struct {
 }
 
 type commandResult struct {
-	State    string          `json:"state"`
-	Subject  string          `json:"subject"`
-	Body     string          `json:"body"`
-	Trailers []resultTrailer `json:"trailers"`
+	State        string          `json:"state"`
+	Subject      string          `json:"subject"`
+	Body         string          `json:"body"`
+	KeepTrailers bool            `json:"keep_trailers"`
+	Trailers     []resultTrailer `json:"trailers"`
 }
 
 type resultTrailer struct {
@@ -184,7 +185,7 @@ func parseSetStateLine(line string) (commandResult, bool, error) {
 }
 
 func applyCommandResult(opts SuperviseOptions, result commandResult) error {
-	_, ok, err := currentWorkingHead(opts)
+	headCommit, ok, err := currentWorkingHead(opts)
 	if err != nil {
 		return err
 	}
@@ -208,6 +209,17 @@ func applyCommandResult(opts SuperviseOptions, result commandResult) error {
 	trailers := []statex.Trailer{{Key: "dwp-state", Value: state}}
 	if strings.TrimSpace(opts.Remote) != "" {
 		trailers = append(trailers, statex.Trailer{Key: "dwp-source", Value: "git:" + strings.TrimSpace(opts.Remote)})
+	}
+	if result.KeepTrailers {
+		reserved := map[string]struct{}{
+			"dwp-state":         {},
+			"dwp-source":        {},
+			"dwp-origin-state":  {},
+			"dwp-run-id":        {},
+			"dwp-runner-id":     {},
+			"dwp-lease-seconds": {},
+		}
+		trailers = appendCopiedDwpTrailers(trailers, headCommit.Trailers, reserved)
 	}
 	for _, trailer := range result.Trailers {
 		key := strings.TrimSpace(trailer.Key)
@@ -359,6 +371,33 @@ func copyAllTrailers(trailers map[string][]string) []statex.Trailer {
 		}
 		for _, value := range trailers[key] {
 			out = append(out, statex.Trailer{Key: trimmedKey, Value: strings.TrimSpace(value)})
+		}
+	}
+	return out
+}
+
+func appendCopiedDwpTrailers(out []statex.Trailer, headTrailers map[string][]string, reserved map[string]struct{}) []statex.Trailer {
+	keys := make([]string, 0, len(headTrailers))
+	for key := range headTrailers {
+		lower := strings.ToLower(strings.TrimSpace(key))
+		if !strings.HasPrefix(lower, "dwp-") {
+			continue
+		}
+		if _, blocked := reserved[lower]; blocked {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return strings.ToLower(strings.TrimSpace(keys[i])) < strings.ToLower(strings.TrimSpace(keys[j]))
+	})
+	for _, key := range keys {
+		normalizedKey := strings.ToLower(strings.TrimSpace(key))
+		for _, value := range headTrailers[key] {
+			if strings.TrimSpace(value) == "" {
+				continue
+			}
+			out = append(out, statex.Trailer{Key: normalizedKey, Value: strings.TrimSpace(value)})
 		}
 	}
 	return out

--- a/go/internal/orchestrator/supervisor.go
+++ b/go/internal/orchestrator/supervisor.go
@@ -3,11 +3,13 @@ package orchestrator
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"all-you-need-is-git/go/internal/gitx"
@@ -106,9 +108,18 @@ func Supervise(opts SuperviseOptions) error {
 	}
 	if waitErr != nil {
 		supervisorLogf(stderrLog, "command exited with error: %v", waitErr)
+		if err := applyFailedCommandResult(opts, waitErr, opts.StdoutLogPath, opts.StderrLogPath); err != nil {
+			supervisorLogf(stderrLog, "failed to mark branch as stalled: %v", err)
+			return err
+		}
+		return nil
 	}
 	if !captured.result.valid {
-		supervisorLogf(stderrLog, "no valid SET_STATE line found; leaving branch in working")
+		supervisorLogf(stderrLog, "no valid SET_STATE line found; refreshing working state")
+		if err := refreshWorkingState(opts); err != nil {
+			supervisorLogf(stderrLog, "failed to refresh working state: %v", err)
+			return err
+		}
 		return nil
 	}
 
@@ -173,18 +184,11 @@ func parseSetStateLine(line string) (commandResult, bool, error) {
 }
 
 func applyCommandResult(opts SuperviseOptions, result commandResult) error {
-	headCommit, err := gitx.ReadCommitInDir(opts.WorktreePath, "HEAD")
+	_, ok, err := currentWorkingHead(opts)
 	if err != nil {
 		return err
 	}
-	headState, invalidState := resolveStateTrailer(headCommit.Trailers)
-	if invalidState != "" {
-		return fmt.Errorf("invalid HEAD state trailer: %s", invalidState)
-	}
-	if headState != "working" {
-		return nil
-	}
-	if strings.TrimSpace(firstTrailer(headCommit.Trailers["dwp-run-id"], "")) != strings.TrimSpace(opts.RunID) {
+	if !ok {
 		return nil
 	}
 
@@ -220,6 +224,144 @@ func applyCommandResult(opts SuperviseOptions, result commandResult) error {
 		return err
 	}
 	return pushCurrentBranchInDir(opts.WorktreePath, opts.Remote)
+}
+
+func applyFailedCommandResult(opts SuperviseOptions, waitErr error, stdoutLogPath string, stderrLogPath string) error {
+	headCommit, ok, err := currentWorkingHead(opts)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	exitCode := exitCodeFromError(waitErr)
+	body := buildFailureBody(exitCode, stdoutLogPath, stderrLogPath)
+	originState := strings.TrimSpace(firstTrailer(headCommit.Trailers["dwp-origin-state"], opts.OriginState))
+	trailers := []statex.Trailer{
+		{Key: "dwp-state", Value: "stalled"},
+		{Key: "dwp-stalled-run", Value: strings.TrimSpace(opts.RunID)},
+	}
+	if originState != "" {
+		trailers = append(trailers, statex.Trailer{Key: "dwp-origin-state", Value: originState})
+	}
+	if strings.TrimSpace(opts.Remote) != "" {
+		trailers = append(trailers, statex.Trailer{Key: "dwp-source", Value: "git:" + strings.TrimSpace(opts.Remote)})
+	}
+
+	if err := statex.CommitState(opts.WorktreePath, "chore: stalled", body, trailers); err != nil {
+		return err
+	}
+	return pushCurrentBranchInDir(opts.WorktreePath, opts.Remote)
+}
+
+func refreshWorkingState(opts SuperviseOptions) error {
+	headCommit, ok, err := currentWorkingHead(opts)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	trailers := copyAllTrailers(headCommit.Trailers)
+	body := "command ended without changing the state, waiting in case it spawns any other process that will eventually change the state"
+	if err := statex.CommitState(opts.WorktreePath, "chore: working", body, trailers); err != nil {
+		return err
+	}
+	return pushCurrentBranchInDir(opts.WorktreePath, opts.Remote)
+}
+
+func currentWorkingHead(opts SuperviseOptions) (gitx.CommitMessage, bool, error) {
+	headCommit, err := gitx.ReadCommitInDir(opts.WorktreePath, "HEAD")
+	if err != nil {
+		return gitx.CommitMessage{}, false, err
+	}
+	headState, invalidState := resolveStateTrailer(headCommit.Trailers)
+	if invalidState != "" {
+		return gitx.CommitMessage{}, false, fmt.Errorf("invalid HEAD state trailer: %s", invalidState)
+	}
+	if headState != "working" {
+		return gitx.CommitMessage{}, false, nil
+	}
+	if strings.TrimSpace(firstTrailer(headCommit.Trailers["dwp-run-id"], "")) != strings.TrimSpace(opts.RunID) {
+		return gitx.CommitMessage{}, false, nil
+	}
+	return headCommit, true, nil
+}
+
+func exitCodeFromError(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+func buildFailureBody(exitCode int, stdoutLogPath string, stderrLogPath string) string {
+	lines := []string{
+		fmt.Sprintf("command exited with code %d", exitCode),
+		"",
+		"last 5 stdout lines:",
+		tailLinesOrPlaceholder(stdoutLogPath, 5),
+		"",
+		"last 5 stderr lines:",
+		tailLinesOrPlaceholder(stderrLogPath, 5),
+	}
+	return strings.Join(lines, "\n")
+}
+
+func tailLinesOrPlaceholder(path string, n int) string {
+	lines, err := tailFileLines(path, n)
+	if err != nil {
+		return fmt.Sprintf("(unable to read log: %v)", err)
+	}
+	if len(lines) == 0 {
+		return "(empty)"
+	}
+	return strings.Join(lines, "\n")
+}
+
+func tailFileLines(path string, n int) ([]string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	normalized := strings.ReplaceAll(string(content), "\r\n", "\n")
+	normalized = strings.TrimRight(normalized, "\n")
+	if normalized == "" {
+		return nil, nil
+	}
+	lines := strings.Split(normalized, "\n")
+	if len(lines) <= n {
+		return lines, nil
+	}
+	return lines[len(lines)-n:], nil
+}
+
+func copyAllTrailers(trailers map[string][]string) []statex.Trailer {
+	keys := make([]string, 0, len(trailers))
+	for key := range trailers {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return strings.ToLower(strings.TrimSpace(keys[i])) < strings.ToLower(strings.TrimSpace(keys[j]))
+	})
+
+	out := make([]statex.Trailer, 0)
+	for _, key := range keys {
+		trimmedKey := strings.TrimSpace(key)
+		if trimmedKey == "" {
+			continue
+		}
+		for _, value := range trailers[key] {
+			out = append(out, statex.Trailer{Key: trimmedKey, Value: strings.TrimSpace(value)})
+		}
+	}
+	return out
 }
 
 func pushCurrentBranchInDir(dir string, remote string) error {

--- a/go/internal/orchestrator/supervisor.go
+++ b/go/internal/orchestrator/supervisor.go
@@ -226,16 +226,32 @@ func applyCommandResult(opts SuperviseOptions, result commandResult) error {
 		if key == "" {
 			return fmt.Errorf("invalid trailer in SET_STATE payload: empty key")
 		}
-		if strings.EqualFold(key, "dwp-state") {
-			return fmt.Errorf("invalid trailer in SET_STATE payload: dwp-state is managed by state")
+		if _, blocked := reservedPayloadTrailerKeys()[strings.ToLower(key)]; blocked {
+			return fmt.Errorf("invalid trailer in SET_STATE payload: %s is managed by aynig", key)
 		}
-		trailers = append(trailers, statex.Trailer{Key: key, Value: strings.TrimSpace(trailer.Value)})
+		parsed := statex.Trailer{Key: key, Value: strings.TrimSpace(trailer.Value)}
+		if err := statex.ValidateTrailer(parsed); err != nil {
+			return err
+		}
+		trailers = append(trailers, parsed)
 	}
 
 	if err := statex.CommitState(opts.WorktreePath, subject, result.Body, trailers); err != nil {
 		return err
 	}
 	return pushCurrentBranchInDir(opts.WorktreePath, opts.Remote)
+}
+
+func reservedPayloadTrailerKeys() map[string]struct{} {
+	return map[string]struct{}{
+		"dwp-state":         {},
+		"dwp-source":        {},
+		"dwp-origin-state":  {},
+		"dwp-run-id":        {},
+		"dwp-runner-id":     {},
+		"dwp-lease-seconds": {},
+		"dwp-stalled-run":   {},
+	}
 }
 
 func applyFailedCommandResult(opts SuperviseOptions, waitErr error, stdoutLogPath string, stderrLogPath string) error {

--- a/go/internal/orchestrator/supervisor.go
+++ b/go/internal/orchestrator/supervisor.go
@@ -1,0 +1,238 @@
+package orchestrator
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"all-you-need-is-git/go/internal/gitx"
+	"all-you-need-is-git/go/internal/statex"
+)
+
+const setStatePrefix = "SET_STATE "
+
+type SuperviseOptions struct {
+	WorktreePath  string
+	BranchName    string
+	CommandPath   string
+	OriginState   string
+	RunID         string
+	Remote        string
+	StdoutLogPath string
+	StderrLogPath string
+}
+
+type commandResult struct {
+	State    string          `json:"state"`
+	Subject  string          `json:"subject"`
+	Body     string          `json:"body"`
+	Trailers []resultTrailer `json:"trailers"`
+}
+
+type resultTrailer struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func Supervise(opts SuperviseOptions) error {
+	if strings.TrimSpace(opts.WorktreePath) == "" {
+		return fmt.Errorf("missing required flag: --worktree-path")
+	}
+	if strings.TrimSpace(opts.CommandPath) == "" {
+		return fmt.Errorf("missing required flag: --command-path")
+	}
+	if strings.TrimSpace(opts.RunID) == "" {
+		return fmt.Errorf("missing required flag: --run-id")
+	}
+	if strings.TrimSpace(opts.StdoutLogPath) == "" {
+		return fmt.Errorf("missing required flag: --stdout-log-path")
+	}
+	if strings.TrimSpace(opts.StderrLogPath) == "" {
+		return fmt.Errorf("missing required flag: --stderr-log-path")
+	}
+	if err := os.MkdirAll(filepath.Dir(opts.StdoutLogPath), 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(opts.StderrLogPath), 0o755); err != nil {
+		return err
+	}
+
+	stdoutLog, err := os.OpenFile(opts.StdoutLogPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer stdoutLog.Close()
+
+	stderrLog, err := os.OpenFile(opts.StderrLogPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer stderrLog.Close()
+
+	stdoutReader, stdoutWriter := io.Pipe()
+	resultCh := make(chan captureResult, 1)
+	go func() {
+		result, captureErr := captureSetState(stdoutReader, stdoutLog)
+		resultCh <- captureResult{result: result, err: captureErr}
+	}()
+
+	cmd := exec.Command(opts.CommandPath)
+	cmd.Dir = opts.WorktreePath
+	cmd.Env = os.Environ()
+	cmd.Stdout = stdoutWriter
+	cmd.Stderr = stderrLog
+	cmd.Stdin = nil
+
+	if err := cmd.Start(); err != nil {
+		_ = stdoutWriter.Close()
+		_ = stdoutReader.Close()
+		supervisorLogf(stderrLog, "failed to start %s: %v", opts.CommandPath, err)
+		<-resultCh
+		return err
+	}
+
+	waitErr := cmd.Wait()
+	_ = stdoutWriter.Close()
+
+	captured := <-resultCh
+	if captured.err != nil {
+		supervisorLogf(stderrLog, "failed to capture stdout: %v", captured.err)
+		return captured.err
+	}
+	if waitErr != nil {
+		supervisorLogf(stderrLog, "command exited with error: %v", waitErr)
+	}
+	if !captured.result.valid {
+		supervisorLogf(stderrLog, "no valid SET_STATE line found; leaving branch in working")
+		return nil
+	}
+
+	if err := applyCommandResult(opts, captured.result.value); err != nil {
+		supervisorLogf(stderrLog, "failed to apply SET_STATE result: %v", err)
+		return err
+	}
+	return nil
+}
+
+type captureResult struct {
+	result parsedResult
+	err    error
+}
+
+type parsedResult struct {
+	valid bool
+	value commandResult
+}
+
+func captureSetState(src io.Reader, log io.Writer) (parsedResult, error) {
+	reader := bufio.NewReader(src)
+	var latest parsedResult
+	for {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			if _, writeErr := io.WriteString(log, line); writeErr != nil {
+				return parsedResult{}, writeErr
+			}
+			if parsed, ok, parseErr := parseSetStateLine(line); parseErr != nil {
+				_, _ = fmt.Fprintf(log, "aynig __supervise: invalid SET_STATE line: %v\n", parseErr)
+			} else if ok {
+				latest = parsedResult{valid: true, value: parsed}
+			}
+		}
+		if err == io.EOF {
+			return latest, nil
+		}
+		if err != nil {
+			return parsedResult{}, err
+		}
+	}
+}
+
+func parseSetStateLine(line string) (commandResult, bool, error) {
+	trimmed := strings.TrimRight(line, "\r\n")
+	if !strings.HasPrefix(trimmed, setStatePrefix) {
+		return commandResult{}, false, nil
+	}
+	payload := strings.TrimSpace(strings.TrimPrefix(trimmed, setStatePrefix))
+	if payload == "" {
+		return commandResult{}, true, fmt.Errorf("empty payload")
+	}
+
+	var result commandResult
+	if err := json.Unmarshal([]byte(payload), &result); err != nil {
+		return commandResult{}, true, err
+	}
+	result.State = strings.ToLower(strings.TrimSpace(result.State))
+	result.Subject = strings.TrimSpace(result.Subject)
+	return result, true, nil
+}
+
+func applyCommandResult(opts SuperviseOptions, result commandResult) error {
+	headCommit, err := gitx.ReadCommitInDir(opts.WorktreePath, "HEAD")
+	if err != nil {
+		return err
+	}
+	headState, invalidState := resolveStateTrailer(headCommit.Trailers)
+	if invalidState != "" {
+		return fmt.Errorf("invalid HEAD state trailer: %s", invalidState)
+	}
+	if headState != "working" {
+		return nil
+	}
+	if strings.TrimSpace(firstTrailer(headCommit.Trailers["dwp-run-id"], "")) != strings.TrimSpace(opts.RunID) {
+		return nil
+	}
+
+	state := strings.ToLower(strings.TrimSpace(result.State))
+	if state == "" {
+		return fmt.Errorf("missing state in SET_STATE payload")
+	}
+	if state == "working" {
+		return fmt.Errorf("invalid state in SET_STATE payload: working")
+	}
+
+	subject := result.Subject
+	if subject == "" {
+		subject = fmt.Sprintf("chore: set %s", state)
+	}
+
+	trailers := []statex.Trailer{{Key: "dwp-state", Value: state}}
+	if strings.TrimSpace(opts.Remote) != "" {
+		trailers = append(trailers, statex.Trailer{Key: "dwp-source", Value: "git:" + strings.TrimSpace(opts.Remote)})
+	}
+	for _, trailer := range result.Trailers {
+		key := strings.TrimSpace(trailer.Key)
+		if key == "" {
+			return fmt.Errorf("invalid trailer in SET_STATE payload: empty key")
+		}
+		if strings.EqualFold(key, "dwp-state") {
+			return fmt.Errorf("invalid trailer in SET_STATE payload: dwp-state is managed by state")
+		}
+		trailers = append(trailers, statex.Trailer{Key: key, Value: strings.TrimSpace(trailer.Value)})
+	}
+
+	if err := statex.CommitState(opts.WorktreePath, subject, result.Body, trailers); err != nil {
+		return err
+	}
+	return pushCurrentBranchInDir(opts.WorktreePath, opts.Remote)
+}
+
+func pushCurrentBranchInDir(dir string, remote string) error {
+	if strings.TrimSpace(remote) == "" {
+		return nil
+	}
+	branch, err := gitx.BranchCurrent(dir)
+	if err != nil {
+		return err
+	}
+	return gitx.Push(dir, remote, branch)
+}
+
+func supervisorLogf(log io.Writer, format string, args ...any) {
+	_, _ = fmt.Fprintf(log, "aynig __supervise: "+format+"\n", args...)
+}

--- a/go/internal/orchestrator/supervisor_test.go
+++ b/go/internal/orchestrator/supervisor_test.go
@@ -31,6 +31,20 @@ func TestParseSetStateLine(t *testing.T) {
 	}
 }
 
+func TestParseSetStateLineReadsKeepTrailers(t *testing.T) {
+	line := "SET_STATE {\"state\":\"review\",\"keep_trailers\":true}\n"
+	result, ok, err := parseSetStateLine(line)
+	if err != nil {
+		t.Fatalf("parseSetStateLine returned error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected SET_STATE line to be recognized")
+	}
+	if !result.KeepTrailers {
+		t.Fatalf("expected keep_trailers to be true")
+	}
+}
+
 func TestSuperviseAppliesLastValidSetState(t *testing.T) {
 	repoDir := initSupervisorTestRepo(t)
 	writeWorkingState(t, repoDir, "run-123", []statex.Trailer{})
@@ -71,6 +85,62 @@ printf 'warn on stderr\n' >&2
 	stderrLog := readFile(t, stderrLogPath)
 	if !strings.Contains(stderrLog, "warn on stderr") {
 		t.Fatalf("stderr log missing command output:\n%s", stderrLog)
+	}
+}
+
+func TestSuperviseKeepsWorkflowTrailersWhenRequested(t *testing.T) {
+	repoDir := initSupervisorTestRepo(t)
+	writeWorkingState(t, repoDir, "run-123", []statex.Trailer{
+		{Key: "dwp-attempt", Value: "2"},
+		{Key: "dwp-max-attempts", Value: "4"},
+		{Key: "dwp-note", Value: "old-note"},
+		{Key: "dwp-issue", Value: "42"},
+	})
+
+	commandPath := writeSupervisorCommand(t, repoDir, "keep.sh", `#!/bin/sh
+printf 'SET_STATE {"state":"review","keep_trailers":true,"trailers":[{"key":"dwp-note","value":"new-note"}]}\n'
+`)
+	stdoutLogPath := filepath.Join(repoDir, ".aynig", "logs", "stdout.log")
+	stderrLogPath := filepath.Join(repoDir, ".aynig", "logs", "stderr.log")
+
+	if err := Supervise(SuperviseOptions{
+		WorktreePath:  repoDir,
+		CommandPath:   commandPath,
+		RunID:         "run-123",
+		StdoutLogPath: stdoutLogPath,
+		StderrLogPath: stderrLogPath,
+	}); err != nil {
+		t.Fatalf("Supervise failed: %v", err)
+	}
+
+	commit, err := gitx.ReadCommitInDir(repoDir, "HEAD")
+	if err != nil {
+		t.Fatalf("ReadCommitInDir failed: %v", err)
+	}
+	if state := firstTrailer(commit.Trailers["dwp-state"], ""); state != "review" {
+		t.Fatalf("expected review state, got %q", state)
+	}
+	if attempt := firstTrailer(commit.Trailers["dwp-attempt"], ""); attempt != "2" {
+		t.Fatalf("expected dwp-attempt trailer to be preserved, got %q", attempt)
+	}
+	if maxAttempts := firstTrailer(commit.Trailers["dwp-max-attempts"], ""); maxAttempts != "4" {
+		t.Fatalf("expected dwp-max-attempts trailer to be preserved, got %q", maxAttempts)
+	}
+	if issue := firstTrailer(commit.Trailers["dwp-issue"], ""); issue != "42" {
+		t.Fatalf("expected dwp-issue trailer to be preserved, got %q", issue)
+	}
+	notes := commit.Trailers["dwp-note"]
+	if len(notes) != 2 || notes[0] != "old-note" || notes[1] != "new-note" {
+		t.Fatalf("expected old and new dwp-note trailers, got %#v", notes)
+	}
+	if originState := firstTrailer(commit.Trailers["dwp-origin-state"], ""); originState != "" {
+		t.Fatalf("expected working-only dwp-origin-state to be dropped, got %q", originState)
+	}
+	if runID := firstTrailer(commit.Trailers["dwp-run-id"], ""); runID != "" {
+		t.Fatalf("expected working-only dwp-run-id to be dropped, got %q", runID)
+	}
+	if lease := firstTrailer(commit.Trailers["dwp-lease-seconds"], ""); lease != "" {
+		t.Fatalf("expected working-only dwp-lease-seconds to be dropped, got %q", lease)
 	}
 }
 

--- a/go/internal/orchestrator/supervisor_test.go
+++ b/go/internal/orchestrator/supervisor_test.go
@@ -144,6 +144,66 @@ printf 'SET_STATE {"state":"review","keep_trailers":true,"trailers":[{"key":"dwp
 	}
 }
 
+func TestSuperviseRejectsReservedPayloadTrailerKeys(t *testing.T) {
+	repoDir := initSupervisorTestRepo(t)
+	writeWorkingState(t, repoDir, "run-123", []statex.Trailer{})
+
+	commandPath := writeSupervisorCommand(t, repoDir, "reserved.sh", `#!/bin/sh
+printf 'SET_STATE {"state":"review","trailers":[{"key":"dwp-run-id","value":"fake"}]}\n'
+`)
+	stdoutLogPath := filepath.Join(repoDir, ".aynig", "logs", "stdout.log")
+	stderrLogPath := filepath.Join(repoDir, ".aynig", "logs", "stderr.log")
+
+	err := Supervise(SuperviseOptions{
+		WorktreePath:  repoDir,
+		CommandPath:   commandPath,
+		RunID:         "run-123",
+		StdoutLogPath: stdoutLogPath,
+		StderrLogPath: stderrLogPath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "dwp-run-id is managed by aynig") {
+		t.Fatalf("expected reserved trailer error, got %v", err)
+	}
+
+	commit, readErr := gitx.ReadCommitInDir(repoDir, "HEAD")
+	if readErr != nil {
+		t.Fatalf("ReadCommitInDir failed: %v", readErr)
+	}
+	if state := firstTrailer(commit.Trailers["dwp-state"], ""); state != "working" {
+		t.Fatalf("expected HEAD to remain in working, got %q", state)
+	}
+}
+
+func TestSuperviseRejectsMalformedPayloadTrailerValues(t *testing.T) {
+	repoDir := initSupervisorTestRepo(t)
+	writeWorkingState(t, repoDir, "run-123", []statex.Trailer{})
+
+	commandPath := writeSupervisorCommand(t, repoDir, "bad-trailer.sh", `#!/bin/sh
+printf 'SET_STATE {"state":"review","trailers":[{"key":"dwp-note","value":"line1\\nline2"}]}\n'
+`)
+	stdoutLogPath := filepath.Join(repoDir, ".aynig", "logs", "stdout.log")
+	stderrLogPath := filepath.Join(repoDir, ".aynig", "logs", "stderr.log")
+
+	err := Supervise(SuperviseOptions{
+		WorktreePath:  repoDir,
+		CommandPath:   commandPath,
+		RunID:         "run-123",
+		StdoutLogPath: stdoutLogPath,
+		StderrLogPath: stderrLogPath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "newlines are not allowed") {
+		t.Fatalf("expected malformed trailer error, got %v", err)
+	}
+
+	commit, readErr := gitx.ReadCommitInDir(repoDir, "HEAD")
+	if readErr != nil {
+		t.Fatalf("ReadCommitInDir failed: %v", readErr)
+	}
+	if state := firstTrailer(commit.Trailers["dwp-state"], ""); state != "working" {
+		t.Fatalf("expected HEAD to remain in working, got %q", state)
+	}
+}
+
 func TestSuperviseRefreshesWorkingWithoutSetState(t *testing.T) {
 	repoDir := initSupervisorTestRepo(t)
 	writeWorkingState(t, repoDir, "run-123", []statex.Trailer{

--- a/go/internal/orchestrator/supervisor_test.go
+++ b/go/internal/orchestrator/supervisor_test.go
@@ -33,7 +33,7 @@ func TestParseSetStateLine(t *testing.T) {
 
 func TestSuperviseAppliesLastValidSetState(t *testing.T) {
 	repoDir := initSupervisorTestRepo(t)
-	writeWorkingState(t, repoDir, "run-123")
+	writeWorkingState(t, repoDir, "run-123", []statex.Trailer{})
 
 	commandPath := writeSupervisorCommand(t, repoDir, "state-command.sh", `#!/bin/sh
 printf 'noise before\n'
@@ -74,9 +74,12 @@ printf 'warn on stderr\n' >&2
 	}
 }
 
-func TestSuperviseLeavesWorkingWithoutSetState(t *testing.T) {
+func TestSuperviseRefreshesWorkingWithoutSetState(t *testing.T) {
 	repoDir := initSupervisorTestRepo(t)
-	writeWorkingState(t, repoDir, "run-123")
+	writeWorkingState(t, repoDir, "run-123", []statex.Trailer{
+		{Key: "dwp-note", Value: "carry-me"},
+		{Key: "dwp-attempt", Value: "2"},
+	})
 	before := runGitOutput(t, repoDir, "rev-parse", "HEAD")
 
 	commandPath := writeSupervisorCommand(t, repoDir, "no-state.sh", `#!/bin/sh
@@ -97,19 +100,96 @@ printf 'nothing to see here\n' >&2
 	}
 
 	after := runGitOutput(t, repoDir, "rev-parse", "HEAD")
-	if before != after {
-		t.Fatalf("expected HEAD to remain unchanged, before=%s after=%s", before, after)
+	if before == after {
+		t.Fatalf("expected HEAD to advance, before=%s after=%s", before, after)
+	}
+
+	commit, err := gitx.ReadCommitInDir(repoDir, "HEAD")
+	if err != nil {
+		t.Fatalf("ReadCommitInDir failed: %v", err)
+	}
+	if state := firstTrailer(commit.Trailers["dwp-state"], ""); state != "working" {
+		t.Fatalf("expected HEAD to stay in working, got %q", state)
+	}
+	if runID := firstTrailer(commit.Trailers["dwp-run-id"], ""); runID != "run-123" {
+		t.Fatalf("expected run id to be preserved, got %q", runID)
+	}
+	if note := firstTrailer(commit.Trailers["dwp-note"], ""); note != "carry-me" {
+		t.Fatalf("expected dwp-note trailer to be preserved, got %q", note)
+	}
+	if attempt := firstTrailer(commit.Trailers["dwp-attempt"], ""); attempt != "2" {
+		t.Fatalf("expected dwp-attempt trailer to be preserved, got %q", attempt)
+	}
+	if !strings.Contains(commit.Body, "command ended without changing the state") {
+		t.Fatalf("unexpected working body: %q", commit.Body)
 	}
 
 	stderrLog := readFile(t, stderrLogPath)
-	if !strings.Contains(stderrLog, "no valid SET_STATE line found") {
+	if !strings.Contains(stderrLog, "no valid SET_STATE line found; refreshing working state") {
 		t.Fatalf("stderr log missing supervisor note:\n%s", stderrLog)
+	}
+}
+
+func TestSuperviseMarksStalledWhenCommandFails(t *testing.T) {
+	repoDir := initSupervisorTestRepo(t)
+	writeWorkingState(t, repoDir, "run-123", []statex.Trailer{})
+
+	commandPath := writeSupervisorCommand(t, repoDir, "fails.sh", `#!/bin/sh
+printf 'line-1\n'
+printf 'line-2\n'
+printf 'line-3\n'
+printf 'line-4\n'
+printf 'line-5\n'
+printf 'line-6\n'
+printf 'SET_STATE {"state":"done","body":"too early"}\n'
+printf 'err-1\n' >&2
+printf 'err-2\n' >&2
+printf 'err-3\n' >&2
+printf 'err-4\n' >&2
+printf 'err-5\n' >&2
+printf 'err-6\n' >&2
+exit 7
+`)
+	stdoutLogPath := filepath.Join(repoDir, ".aynig", "logs", "stdout.log")
+	stderrLogPath := filepath.Join(repoDir, ".aynig", "logs", "stderr.log")
+
+	if err := Supervise(SuperviseOptions{
+		WorktreePath:  repoDir,
+		CommandPath:   commandPath,
+		RunID:         "run-123",
+		StdoutLogPath: stdoutLogPath,
+		StderrLogPath: stderrLogPath,
+	}); err != nil {
+		t.Fatalf("Supervise failed: %v", err)
+	}
+
+	commit, err := gitx.ReadCommitInDir(repoDir, "HEAD")
+	if err != nil {
+		t.Fatalf("ReadCommitInDir failed: %v", err)
+	}
+	if state := firstTrailer(commit.Trailers["dwp-state"], ""); state != "stalled" {
+		t.Fatalf("expected stalled state, got %q", state)
+	}
+	if stalledRun := firstTrailer(commit.Trailers["dwp-stalled-run"], ""); stalledRun != "run-123" {
+		t.Fatalf("expected stalled run trailer, got %q", stalledRun)
+	}
+	if !strings.Contains(commit.Body, "command exited with code 7") {
+		t.Fatalf("expected exit code in stalled body, got %q", commit.Body)
+	}
+	if !strings.Contains(commit.Body, "line-3\nline-4\nline-5\nline-6\nSET_STATE {\"state\":\"done\",\"body\":\"too early\"}") {
+		t.Fatalf("expected stdout tail in stalled body, got %q", commit.Body)
+	}
+	if strings.Contains(commit.Body, "line-1") {
+		t.Fatalf("expected stalled body to include only the stdout tail, got %q", commit.Body)
+	}
+	if !strings.Contains(commit.Body, "err-3\nerr-4\nerr-5\nerr-6\naynig __supervise: command exited with error: exit status 7") {
+		t.Fatalf("expected stderr tail in stalled body, got %q", commit.Body)
 	}
 }
 
 func TestSuperviseSkipsStateUpdateWhenRunIDChanges(t *testing.T) {
 	repoDir := initSupervisorTestRepo(t)
-	writeWorkingState(t, repoDir, "run-123")
+	writeWorkingState(t, repoDir, "run-123", []statex.Trailer{})
 	before := runGitOutput(t, repoDir, "rev-parse", "HEAD")
 
 	commandPath := writeSupervisorCommand(t, repoDir, "mismatch.sh", `#!/bin/sh
@@ -152,14 +232,16 @@ func initSupervisorTestRepo(t *testing.T) string {
 	return repoDir
 }
 
-func writeWorkingState(t *testing.T, repoDir string, runID string) {
+func writeWorkingState(t *testing.T, repoDir string, runID string, extraTrailers []statex.Trailer) {
 	t.Helper()
-	err := statex.CommitState(repoDir, "chore: working", "lease", []statex.Trailer{
+	trailers := []statex.Trailer{
 		{Key: "dwp-state", Value: "working"},
 		{Key: "dwp-origin-state", Value: "review"},
 		{Key: "dwp-run-id", Value: runID},
 		{Key: "dwp-lease-seconds", Value: "300"},
-	})
+	}
+	trailers = append(trailers, extraTrailers...)
+	err := statex.CommitState(repoDir, "chore: working", "lease", trailers)
 	if err != nil {
 		t.Fatalf("CommitState failed: %v", err)
 	}

--- a/go/internal/orchestrator/supervisor_test.go
+++ b/go/internal/orchestrator/supervisor_test.go
@@ -1,0 +1,204 @@
+package orchestrator
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"all-you-need-is-git/go/internal/gitx"
+	"all-you-need-is-git/go/internal/statex"
+)
+
+func TestParseSetStateLine(t *testing.T) {
+	line := "SET_STATE {\"state\":\"review\",\"subject\":\"ready\",\"body\":\"line1\\nline2\"}\n"
+	result, ok, err := parseSetStateLine(line)
+	if err != nil {
+		t.Fatalf("parseSetStateLine returned error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected SET_STATE line to be recognized")
+	}
+	if result.State != "review" {
+		t.Fatalf("unexpected state: %q", result.State)
+	}
+	if result.Subject != "ready" {
+		t.Fatalf("unexpected subject: %q", result.Subject)
+	}
+	if result.Body != "line1\nline2" {
+		t.Fatalf("unexpected body: %q", result.Body)
+	}
+}
+
+func TestSuperviseAppliesLastValidSetState(t *testing.T) {
+	repoDir := initSupervisorTestRepo(t)
+	writeWorkingState(t, repoDir, "run-123")
+
+	commandPath := writeSupervisorCommand(t, repoDir, "state-command.sh", `#!/bin/sh
+printf 'noise before\n'
+printf 'SET_STATE {"state":"review","body":"first"}\n'
+printf 'SET_STATE {"state":"complete","subject":"ship","body":"line1\\nline2","trailers":[{"key":"dwp-note","value":"ready"}]}\n'
+printf 'warn on stderr\n' >&2
+`)
+	stdoutLogPath := filepath.Join(repoDir, ".aynig", "logs", "stdout.log")
+	stderrLogPath := filepath.Join(repoDir, ".aynig", "logs", "stderr.log")
+
+	if err := Supervise(SuperviseOptions{
+		WorktreePath:  repoDir,
+		CommandPath:   commandPath,
+		RunID:         "run-123",
+		StdoutLogPath: stdoutLogPath,
+		StderrLogPath: stderrLogPath,
+	}); err != nil {
+		t.Fatalf("Supervise failed: %v", err)
+	}
+
+	fullMessage := runGitOutput(t, repoDir, "log", "-1", "--format=%B")
+	wantMessage := statex.BuildCommitMessage("ship", "line1\nline2", []statex.Trailer{
+		{Key: "dwp-state", Value: "complete"},
+		{Key: "dwp-note", Value: "ready"},
+	})
+	if strings.TrimRight(fullMessage, "\n") != strings.TrimRight(wantMessage, "\n") {
+		t.Fatalf("unexpected commit message:\n%s", fullMessage)
+	}
+
+	stdoutLog := readFile(t, stdoutLogPath)
+	if !strings.Contains(stdoutLog, `SET_STATE {"state":"complete","subject":"ship","body":"line1\nline2","trailers":[{"key":"dwp-note","value":"ready"}]}`) {
+		t.Fatalf("stdout log missing final SET_STATE line:\n%s", stdoutLog)
+	}
+
+	stderrLog := readFile(t, stderrLogPath)
+	if !strings.Contains(stderrLog, "warn on stderr") {
+		t.Fatalf("stderr log missing command output:\n%s", stderrLog)
+	}
+}
+
+func TestSuperviseLeavesWorkingWithoutSetState(t *testing.T) {
+	repoDir := initSupervisorTestRepo(t)
+	writeWorkingState(t, repoDir, "run-123")
+	before := runGitOutput(t, repoDir, "rev-parse", "HEAD")
+
+	commandPath := writeSupervisorCommand(t, repoDir, "no-state.sh", `#!/bin/sh
+printf 'still working\n'
+printf 'nothing to see here\n' >&2
+`)
+	stdoutLogPath := filepath.Join(repoDir, ".aynig", "logs", "stdout.log")
+	stderrLogPath := filepath.Join(repoDir, ".aynig", "logs", "stderr.log")
+
+	if err := Supervise(SuperviseOptions{
+		WorktreePath:  repoDir,
+		CommandPath:   commandPath,
+		RunID:         "run-123",
+		StdoutLogPath: stdoutLogPath,
+		StderrLogPath: stderrLogPath,
+	}); err != nil {
+		t.Fatalf("Supervise failed: %v", err)
+	}
+
+	after := runGitOutput(t, repoDir, "rev-parse", "HEAD")
+	if before != after {
+		t.Fatalf("expected HEAD to remain unchanged, before=%s after=%s", before, after)
+	}
+
+	stderrLog := readFile(t, stderrLogPath)
+	if !strings.Contains(stderrLog, "no valid SET_STATE line found") {
+		t.Fatalf("stderr log missing supervisor note:\n%s", stderrLog)
+	}
+}
+
+func TestSuperviseSkipsStateUpdateWhenRunIDChanges(t *testing.T) {
+	repoDir := initSupervisorTestRepo(t)
+	writeWorkingState(t, repoDir, "run-123")
+	before := runGitOutput(t, repoDir, "rev-parse", "HEAD")
+
+	commandPath := writeSupervisorCommand(t, repoDir, "mismatch.sh", `#!/bin/sh
+printf 'SET_STATE {"state":"review","body":"done"}\n'
+`)
+	stdoutLogPath := filepath.Join(repoDir, ".aynig", "logs", "stdout.log")
+	stderrLogPath := filepath.Join(repoDir, ".aynig", "logs", "stderr.log")
+
+	if err := Supervise(SuperviseOptions{
+		WorktreePath:  repoDir,
+		CommandPath:   commandPath,
+		RunID:         "run-999",
+		StdoutLogPath: stdoutLogPath,
+		StderrLogPath: stderrLogPath,
+	}); err != nil {
+		t.Fatalf("Supervise failed: %v", err)
+	}
+
+	after := runGitOutput(t, repoDir, "rev-parse", "HEAD")
+	if before != after {
+		t.Fatalf("expected HEAD to remain unchanged, before=%s after=%s", before, after)
+	}
+
+	commit, err := gitx.ReadCommitInDir(repoDir, "HEAD")
+	if err != nil {
+		t.Fatalf("ReadCommitInDir failed: %v", err)
+	}
+	if state := firstTrailer(commit.Trailers["dwp-state"], ""); state != "working" {
+		t.Fatalf("expected HEAD to stay in working, got %q", state)
+	}
+}
+
+func initSupervisorTestRepo(t *testing.T) string {
+	t.Helper()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", ".")
+	runGit(t, repoDir, "config", "user.email", "test@example.com")
+	runGit(t, repoDir, "config", "user.name", "Test User")
+	runGit(t, repoDir, "commit", "--allow-empty", "-m", "seed")
+	return repoDir
+}
+
+func writeWorkingState(t *testing.T, repoDir string, runID string) {
+	t.Helper()
+	err := statex.CommitState(repoDir, "chore: working", "lease", []statex.Trailer{
+		{Key: "dwp-state", Value: "working"},
+		{Key: "dwp-origin-state", Value: "review"},
+		{Key: "dwp-run-id", Value: runID},
+		{Key: "dwp-lease-seconds", Value: "300"},
+	})
+	if err != nil {
+		t.Fatalf("CommitState failed: %v", err)
+	}
+}
+
+func writeSupervisorCommand(t *testing.T, repoDir string, name string, script string) string {
+	t.Helper()
+	commandPath := filepath.Join(repoDir, name)
+	if err := os.WriteFile(commandPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write command failed: %v", err)
+	}
+	return commandPath
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v (%s)", args, err, string(output))
+	}
+}
+
+func runGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v (%s)", args, err, string(output))
+	}
+	return string(output)
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file failed: %v", err)
+	}
+	return string(content)
+}

--- a/go/internal/statex/state_commit.go
+++ b/go/internal/statex/state_commit.go
@@ -3,6 +3,7 @@ package statex
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"all-you-need-is-git/go/internal/gitx"
@@ -11,6 +12,22 @@ import (
 type Trailer struct {
 	Key   string
 	Value string
+}
+
+var trailerKeyPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]*$`)
+
+func ValidateTrailer(trailer Trailer) error {
+	key := strings.TrimSpace(trailer.Key)
+	if key == "" {
+		return errors.New("Invalid trailer: empty key")
+	}
+	if !trailerKeyPattern.MatchString(key) {
+		return fmt.Errorf("Invalid trailer key: %q", trailer.Key)
+	}
+	if strings.Contains(trailer.Value, "\n") || strings.Contains(trailer.Value, "\r") {
+		return fmt.Errorf("Invalid trailer value for %q: newlines are not allowed", key)
+	}
+	return nil
 }
 
 func BuildCommitMessage(subject string, prompt string, trailers []Trailer) string {

--- a/go/internal/statex/state_commit_test.go
+++ b/go/internal/statex/state_commit_test.go
@@ -109,6 +109,52 @@ func TestVerifyHeadStateTrailer(t *testing.T) {
 	}
 }
 
+func TestValidateTrailer(t *testing.T) {
+	tests := []struct {
+		name        string
+		trailer     Trailer
+		wantErrText string
+	}{
+		{
+			name:    "valid trailer",
+			trailer: Trailer{Key: "dwp-note", Value: "hello"},
+		},
+		{
+			name:        "empty key",
+			trailer:     Trailer{Key: "   ", Value: "hello"},
+			wantErrText: "Invalid trailer: empty key",
+		},
+		{
+			name:        "invalid key format",
+			trailer:     Trailer{Key: "bad key", Value: "hello"},
+			wantErrText: `Invalid trailer key: "bad key"`,
+		},
+		{
+			name:        "newline in value",
+			trailer:     Trailer{Key: "dwp-note", Value: "line1\nline2"},
+			wantErrText: `Invalid trailer value for "dwp-note": newlines are not allowed`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTrailer(tt.trailer)
+			if tt.wantErrText == "" {
+				if err != nil {
+					t.Fatalf("ValidateTrailer() error = %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateTrailer() error = nil, want %q", tt.wantErrText)
+			}
+			if err.Error() != tt.wantErrText {
+				t.Fatalf("ValidateTrailer() error = %q, want %q", err.Error(), tt.wantErrText)
+			}
+		})
+	}
+}
+
 func initGitRepo(t *testing.T) string {
 	t.Helper()
 


### PR DESCRIPTION
## What changed

This PR teaches `aynig run` to close the workflow loop automatically.

- `aynig run` now launches a private `aynig __supervise` process instead of executing the state command directly.
- The supervisor runs the real command, captures `stdout` and `stderr` into separate log files, and watches `stdout` for lines that begin with `SET_STATE `.
- When the command exits, the supervisor applies the last valid `SET_STATE {...}` it observed, as long as `HEAD` is still `working` for the same `dwp-run-id`.
- If no valid `SET_STATE` is emitted, the branch stays in `working` and the lease policy continues to govern recovery.
- The command environment now exposes `STDOUT_LOG_PATH` and `STDERR_LOG_PATH` instead of a single combined `LOG_PATH`.

## Why

The current runner hands control to the command and then stops. That leaves every workflow command responsible for creating the next state commit itself, which is the expected end state in almost every flow.

This change moves commit materialization back into the runner while keeping state selection in the command. Commands now declare the next state explicitly with `SET_STATE {...}` and the runner turns that declaration into the final commit.

## Impact

- Workflow commands should emit `SET_STATE {...}` on `stdout`.
- `stderr` is no longer part of the state-transition protocol.
- Docs, examples, and the published contract now describe the new protocol end to end.

## Validation

- `go test ./...`